### PR TITLE
feat: introduce capsule CLI for scaffolding and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,23 @@ Shadow DOM v1, `::part`, and container queries are supported in all modern everg
 Capsule doesn’t bypass a11y—your components still need focus states, ARIA, contrast, keyboard handling, and reduced-motion respect. The isolation helps keep a11y styles consistent.
 
 ---
+
+## CLI
+
+Capsule provides a small command line interface in `packages/capsule-cli`.
+
+### Local development
+
+```bash
+cd packages/capsule-cli
+npm install
+npm link # exposes a global `capsule` command
+```
+
+### Usage
+
+```bash
+capsule new component Button  # scaffolds a new component skeleton
+capsule tokens build          # runs the token pipeline (npm run tokens:build)
+capsule check                 # runs lint tasks (npm run lint)
+```

--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function usage() {
+  console.log(`Usage:\n  capsule new component <Name>\n  capsule tokens build\n  capsule check`);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  usage();
+  process.exit(0);
+}
+
+const [cmd, subcmd, name] = args;
+
+switch (cmd) {
+  case 'new':
+    if (subcmd === 'component' && name) {
+      scaffoldComponent(name);
+    } else {
+      usage();
+    }
+    break;
+  case 'tokens':
+    if (subcmd === 'build') {
+      runCommand('npm', ['run', 'tokens:build']);
+    } else {
+      usage();
+    }
+    break;
+  case 'check':
+    runCommand('npm', ['run', 'lint']);
+    break;
+  default:
+    usage();
+}
+
+function runCommand(command, params) {
+  const res = spawnSync(command, params, { stdio: 'inherit' });
+  if (res.status !== 0) {
+    process.exit(res.status ?? 1);
+  }
+}
+
+function scaffoldComponent(rawName) {
+  const name = rawName.charAt(0).toUpperCase() + rawName.slice(1);
+  const baseDir = join(process.cwd(), 'packages', 'components', name);
+  if (existsSync(baseDir)) {
+    console.error(`Component "${name}" already exists`);
+    process.exit(1);
+  }
+  mkdirSync(baseDir, { recursive: true });
+
+  const componentFile = join(baseDir, `${name}.ts`);
+  const styleFile = join(baseDir, 'style.ts');
+
+  const componentSrc = `export const ${name} = () => {\n  // TODO: implement ${name} component\n};\n`;
+  const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
+
+  writeFileSync(componentFile, componentSrc, 'utf8');
+  writeFileSync(styleFile, styleSrc, 'utf8');
+  console.log(`Scaffolded component at ${baseDir}`);
+}

--- a/packages/capsule-cli/package.json
+++ b/packages/capsule-cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "capsule-cli",
+  "version": "0.1.0",
+  "description": "Command line utilities for Capsule UI",
+  "bin": {
+    "capsule": "./bin/capsule.js"
+  },
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add `capsule-cli` package with a `capsule` binary
- implement commands for scaffolding components, running token builds, and lint checks
- document CLI usage and local development in README

## Testing
- `node packages/capsule-cli/bin/capsule.js`
- `node packages/capsule-cli/bin/capsule.js tokens build` *(fails: Could not read package.json)*
- `node packages/capsule-cli/bin/capsule.js check` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d6d12c083288e12ca39a0ba30e0