### PR TITLE
docs: add ADR template

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Capsule works best with a few non-negotiables:
   - Require `@layer components` in component CSS files.
 - **Build checks:** fail if runtime CSS-in-JS packages are imported in components (allow-list exceptions).
 - **Storybook + VRT:** each component shows theme × density × locale, with visual regression tests.
+## Architecture Decision Records
+See [docs/adr](docs/adr/README.md) for existing decisions and guidance on writing new ones.
 
 ---
 

--- a/docs/adr/000-style-contract-template.md
+++ b/docs/adr/000-style-contract-template.md
@@ -1,0 +1,23 @@
+# ADR 000: Style Contract Template
+
+## Status
+Draft
+
+## Context
+Explain why this style decision is needed and what problem it addresses.
+
+## Decision
+### Scope by default
+Describe how component styles are isolated (e.g., Shadow DOM, CSS Modules) and why this approach is chosen.
+
+### Token usage
+List the design tokens exposed as CSS custom properties and reference them instead of hard-coded values.
+
+### Layer ordering
+Detail how the component participates in the shared `@layer` stack and the expected order of styles.
+
+### Variant strategy
+Explain how variants map to CSS classes or attributes and whether they compile at build time.
+
+## Consequences
+Note any trade-offs, follow-up work, or implications of this decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records
+
+This directory houses ADRs for Capsule.
+
+To create a new ADR:
+
+1. Copy the [template](000-style-contract-template.md) to a new file with the next number, e.g. `001-your-decision.md`.
+2. Update the title, fill in the sections, and set the initial status.
+3. Commit the file and reference it from discussions or pull requests.


### PR DESCRIPTION
## Summary
- add ADR template for style contracts
- document ADR usage and template location
- link ADR directory from main README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d6abffc8328a385b6d1e3a903b7