### PR TITLE
Add booking widget example with runtime theming

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Booking Widget Example
+
+This directory demonstrates a minimal Capsule widget built with Shadow DOM.
+
+## Usage
+
+Include the widget on a page:
+
+```html
+<script type="module" src="./booking-widget.js"></script>
+<booking-widget id="w"></booking-widget>
+```
+
+Theme it at runtime by changing CSS variables or attributes:
+
+```js
+const w = document.getElementById('w');
+w.style.setProperty('--bk-brand', '#ff3b3b');
+w.setAttribute('theme', 'dark');
+```
+
+Customize exposed parts safely:
+
+```css
+booking-widget::part(button) { text-transform: uppercase; }
+booking-widget::part(card) { border-radius: 24px; }
+```
+
+Open `index.html` in a modern browser to see the widget and runtime theming in action.

--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -1,0 +1,39 @@
+customElements.define("booking-widget", class extends HTMLElement {
+  constructor() {
+    super();
+    const r = this.attachShadow({ mode: "open" });
+    r.innerHTML = `
+      <style>
+        @layer reset, base, components;
+        :host {
+          --bk-brand: #4f46e5;
+          --bk-text: #0f172a;
+          container-type: inline-size;
+          display: block;
+          color: var(--bk-text);
+        }
+        :host([theme="dark"]) {
+          --bk-text: #e6e8ef;
+        }
+        @layer base {
+          .card {
+            padding: 1rem;
+            border: 1px solid var(--bk-brand);
+            border-radius: 16px;
+          }
+          .button {
+            background: var(--bk-brand);
+            color: white;
+            border: 0;
+            padding: .7rem 1rem;
+            border-radius: 12px;
+            cursor: pointer;
+          }
+        }
+      </style>
+      <div class="card" part="card">
+        <button class="button" part="button">Book</button>
+      </div>
+    `;
+  }
+});

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Booking Widget Demo</title>
+    <script type="module" src="./booking-widget.js"></script>
+    <style>
+      body { font-family: sans-serif; padding: 2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Booking Widget Demo</h1>
+    <booking-widget id="w"></booking-widget>
+    <script>
+      const w = document.getElementById('w');
+      // runtime theming after load
+      setTimeout(() => {
+        w.style.setProperty('--bk-brand', '#ff3b3b');
+        w.setAttribute('theme', 'dark');
+      }, 1000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Shadow DOM booking widget exposing CSS vars and `::part` hooks
- provide demo page showing runtime theming
- document usage and customization in example README

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d69a024832897e8917ad14bcc6f