### PR TITLE
Use tokens in booking widget example

### DIFF
--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -6,14 +6,14 @@ customElements.define("booking-widget", class extends HTMLElement {
       <style>
         @layer reset, base, components;
         :host {
-          --bk-brand: #4f46e5;
-          --bk-text: #0f172a;
+          --bk-brand: var(--color-brand);
+          --bk-text: var(--color-text);
           container-type: inline-size;
           display: block;
           color: var(--bk-text);
         }
         :host([theme="dark"]) {
-          --bk-text: #e6e8ef;
+          --bk-text: var(--color-text);
         }
         @layer base {
           .card {

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Booking Widget Demo</title>
+    <link rel="stylesheet" href="../dist/tokens.css">
     <script type="module" src="./booking-widget.js"></script>
     <style>
       body { font-family: sans-serif; padding: 2rem; }


### PR DESCRIPTION
## Summary
- import design tokens stylesheet into example index page
- reference design token variables instead of hard-coded colors in booking widget

## Testing
- `npm run lint:js` (fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')
- `npm run lint:css` (fails: Invalid option for scale-unlimited/declaration-strict-value)


------
https://chatgpt.com/codex/tasks/task_e_689cc07e06588328ba9e177b52339d76