### PR TITLE
feat: build tokens for dynamic themes

### DIFF
--- a/dist/tokens.d.ts
+++ b/dist/tokens.d.ts
@@ -1,5 +1,6 @@
+export type ThemeName = 'light' | 'dark';
 export type TokenName = '--color-background' | '--color-text' | '--color-brand' | '--spacing-sm' | '--spacing-md' | '--spacing-lg';
-export interface TokenValues { light: string; dark: string; }
+export type TokenValues = Record<ThemeName, string>;
 export const tokens: Record<TokenName, TokenValues>;
 export default tokens;
 

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -28,32 +28,65 @@ async function build() {
   const raw = JSON.parse(await fs.readFile(src, 'utf8')) as TokenNode;
   const tokens = flattenTokens(raw);
 
-  const light: string[] = [];
-  const dark: string[] = [];
-  const jsonOut: Record<string, { light: string; dark: string }> = {};
+  // Gather all theme names across tokens
+  const themeNames = new Set<string>();
+  for (const t of tokens) {
+    if (typeof t.value === 'object') {
+      for (const theme of Object.keys(t.value)) {
+        themeNames.add(theme);
+      }
+    }
+  }
+  if (themeNames.size === 0) themeNames.add('light');
+
+  // Prepare containers for CSS and JSON outputs
+  const themes: Record<string, string[]> = {};
+  for (const theme of themeNames) {
+    themes[theme] = [];
+  }
+  const jsonOut: Record<string, Record<string, string>> = {};
 
   for (const t of tokens) {
     const cssVar = '--' + t.name.replace(/\./g, '-');
-    let lightVal: string;
-    let darkVal: string;
-    if (typeof t.value === 'object') {
-      lightVal = t.value.light;
-      darkVal = t.value.dark ?? t.value.light;
-    } else {
-      lightVal = t.value;
-      darkVal = t.value;
+    const defaultVal =
+      typeof t.value === 'object'
+        ? t.value.light ?? Object.values(t.value)[0]
+        : t.value;
+    for (const theme of themeNames) {
+      const val =
+        typeof t.value === 'object' ? t.value[theme] ?? defaultVal : defaultVal;
+      themes[theme].push(`  ${cssVar}: ${val};`);
+      if (!jsonOut[cssVar]) jsonOut[cssVar] = {};
+      jsonOut[cssVar][theme] = val;
     }
-    light.push(`  ${cssVar}: ${lightVal};`);
-    dark.push(`  ${cssVar}: ${darkVal};`);
-    jsonOut[cssVar] = { light: lightVal, dark: darkVal };
   }
 
-  const css = `:root{\n${light.join('\n')}\n}\n\n[data-theme="dark"]{\n${dark.join('\n')}\n}\n`;
+  const defaultTheme = themeNames.has('light')
+    ? 'light'
+    : Array.from(themeNames)[0];
+  let css = `:root{\n${themes[defaultTheme].join('\n')}\n}`;
+  for (const theme of themeNames) {
+    if (theme === defaultTheme) continue;
+    css += `\n\n[data-theme="${theme}"]{\n${themes[theme].join('\n')}\n}`;
+  }
   await fs.writeFile(path.join(dist, 'tokens.css'), css + '\n');
-  await fs.writeFile(path.join(dist, 'tokens.json'), JSON.stringify(jsonOut, null, 2) + '\n');
+  await fs.writeFile(
+    path.join(dist, 'tokens.json'),
+    JSON.stringify(jsonOut, null, 2) + '\n'
+  );
 
-  const names = Object.keys(jsonOut).map(n => `'${n}'`).join(' | ');
-  const dts = `export type TokenName = ${names};\nexport interface TokenValues { light: string; dark: string; }\nexport const tokens: Record<TokenName, TokenValues>;\nexport default tokens;\n`;
+  const names = Object.keys(jsonOut)
+    .map(n => `'${n}'`)
+    .join(' | ');
+  const themeUnion = Array.from(themeNames)
+    .map(t => `'${t}'`)
+    .join(' | ');
+  const dts =
+    `export type ThemeName = ${themeUnion};\n` +
+    `export type TokenName = ${names};\n` +
+    `export type TokenValues = Record<ThemeName, string>;\n` +
+    `export const tokens: Record<TokenName, TokenValues>;\n` +
+    `export default tokens;\n`;
   await fs.writeFile(path.join(dist, 'tokens.d.ts'), dts + '\n');
 }
 


### PR DESCRIPTION
## Summary
- support building tokens for any theme by iterating over theme keys
- generate theme-specific CSS blocks and JSON entries dynamically
- expose `ThemeName` and generic `TokenValues` types

## Testing
- `npm run lint:js` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*
- `npm run lint:css` *(fails: Invalid option for rule 'scale-unlimited/declaration-strict-value')*


------
https://chatgpt.com/codex/tasks/task_e_689cc07c98d4832888395845646b9fbc