### PR TITLE
chore: derive script base dir for token build

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 
+const baseDir = path.dirname(new URL(import.meta.url).pathname);
+
 interface TokenNode {
   $type?: string;
   $value?: any;
@@ -22,8 +24,8 @@ function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] =
 }
 
 async function build() {
-  const src = path.join('tokens', 'source', 'tokens.json');
-  const dist = 'dist';
+  const src = path.join(baseDir, '..', 'tokens', 'source', 'tokens.json');
+  const dist = path.join(baseDir, '..', 'dist');
   await fs.mkdir(dist, { recursive: true });
   const raw = JSON.parse(await fs.readFile(src, 'utf8')) as TokenNode;
   const tokens = flattenTokens(raw);


### PR DESCRIPTION
## Summary
- make token build script resolve paths from its own directory

## Testing
- `npm run lint:js` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*
- `npm run lint:css` *(fails: Invalid option for scale-unlimited/declaration-strict-value)*

------
https://chatgpt.com/codex/tasks/task_e_689cc07bc5ec8328a2640621fca0a094