### PR TITLE
chore: update eslint components path

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['src/components/**/*.{js,jsx,ts,tsx}'],
+      files: ['packages/components/**/*.{js,jsx,ts,tsx}'],
       rules: {
         'no-restricted-imports': [
           'error',


### PR DESCRIPTION
## Summary
- lint components from packages folder

## Testing
- `npm run lint:js` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*


------
https://chatgpt.com/codex/tasks/task_e_689cc4af338483289ea388423e2ecf1d