### PR TITLE
fix: resolve stylelint errors

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -8,8 +8,7 @@ module.exports = {
     'scale-unlimited/declaration-strict-value': [
       ['/color/', 'fill', 'stroke'],
       {
-        ignoreValues: ['transparent', 'inherit', 'currentColor'],
-        ignoreFunctions: ['var']
+        ignoreValues: ['transparent', 'inherit', 'currentColor']
       }
     ],
     'capsule-ui/require-layer': true

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,3 +1,4 @@
+@layer components;
 :root{
   --color-background: #ffffff;
   --color-text: #0f172a;
@@ -15,4 +16,3 @@
   --spacing-md: 8px;
   --spacing-lg: 16px;
 }
-

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -66,7 +66,7 @@ async function build() {
   const defaultTheme = themeNames.has('light')
     ? 'light'
     : Array.from(themeNames)[0];
-  let css = `:root{\n${themes[defaultTheme].join('\n')}\n}`;
+  let css = `@layer components;\n:root{\n${themes[defaultTheme].join('\n')}\n}`;
   for (const theme of themeNames) {
     if (theme === defaultTheme) continue;
     css += `\n\n[data-theme="${theme}"]{\n${themes[theme].join('\n')}\n}`;


### PR DESCRIPTION
## Summary
- fix stylelint plugin configuration for allowed CSS values
- ensure generated token CSS declares the components layer

## Testing
- `npm run lint:css`
- `npm run lint` *(fails: Parsing error: 'import' and 'export' may appear only with 'sourceType: module')*

------
https://chatgpt.com/codex/tasks/task_e_689cca0116ac83288fcb9738c62b7ff7