### PR TITLE
feat: improve booking widget accessibility

### DIFF
--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -29,10 +29,14 @@ customElements.define("booking-widget", class extends HTMLElement {
             border-radius: 12px;
             cursor: pointer;
           }
+          .button:focus-visible {
+            outline: 2px solid var(--bk-text);
+            outline-offset: 2px;
+          }
         }
       </style>
       <div class="card" part="card">
-        <button class="button" part="button">Book</button>
+        <button class="button" part="button" aria-label="Book reservation">Book</button>
       </div>
     `;
   }

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,6 +11,7 @@
   </head>
   <body>
     <h1>Booking Widget Demo</h1>
+    <p>Use Tab to focus the button; it includes an accessible label and focus style.</p>
     <booking-widget id="w"></booking-widget>
     <script>
       const w = document.getElementById('w');


### PR DESCRIPTION
## Summary
- add descriptive `aria-label` for booking button
- show keyboard focus using `:focus-visible`
- document accessibility in example page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ccecec8dc8328af2ac290c8de1cc4