### PR TITLE
feat(cli): use async fs for component scaffolding

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { access, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
@@ -20,7 +20,7 @@ program
   .description('Scaffold a new resource')
   .argument('<type>', 'Resource type (currently only "component" is supported)')
   .argument('<name>', 'Name of the component')
-  .action((type, name) => {
+  .action(async (type, name) => {
     if (type !== 'component') {
       console.error('Error: only "component" type is supported.');
       process.exit(1);
@@ -29,7 +29,7 @@ program
       console.error('Error: component name is required.');
       process.exit(1);
     }
-    scaffoldComponent(name);
+    await scaffoldComponent(name);
   });
 
 const tokens = program.command('tokens').description('Design token utilities');
@@ -53,22 +53,32 @@ function runCommand(command, params) {
   }
 }
 
-function scaffoldComponent(rawName) {
-  const name = rawName.charAt(0).toUpperCase() + rawName.slice(1);
-  const baseDir = join(process.cwd(), 'packages', 'components', name);
-  if (existsSync(baseDir)) {
-    console.error(`Component "${name}" already exists`);
+export async function scaffoldComponent(rawName) {
+  try {
+    const name = rawName.charAt(0).toUpperCase() + rawName.slice(1);
+    const baseDir = join(process.cwd(), 'packages', 'components', name);
+
+    try {
+      await access(baseDir);
+      console.error(`Component "${name}" already exists`);
+      process.exit(1);
+    } catch {
+      // directory does not exist; continue
+    }
+
+    await mkdir(baseDir, { recursive: true });
+
+    const componentFile = join(baseDir, `${name}.ts`);
+    const styleFile = join(baseDir, 'style.ts');
+
+    const componentSrc = `export const ${name} = () => {\n  // TODO: implement ${name} component\n};\n`;
+    const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
+
+    await writeFile(componentFile, componentSrc, 'utf8');
+    await writeFile(styleFile, styleSrc, 'utf8');
+    console.log(`Scaffolded component at ${baseDir}`);
+  } catch (err) {
+    console.error('Error scaffolding component:', err);
     process.exit(1);
   }
-  mkdirSync(baseDir, { recursive: true });
-
-  const componentFile = join(baseDir, `${name}.ts`);
-  const styleFile = join(baseDir, 'style.ts');
-
-  const componentSrc = `export const ${name} = () => {\n  // TODO: implement ${name} component\n};\n`;
-  const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
-
-  writeFileSync(componentFile, componentSrc, 'utf8');
-  writeFileSync(styleFile, styleSrc, 'utf8');
-  console.log(`Scaffolded component at ${baseDir}`);
 }


### PR DESCRIPTION
## Summary
- refactor component scaffolding to use `node:fs/promises`
- wrap operations in try/catch for clearer errors
- expose async `scaffoldComponent` and await it in command handler

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689cced1542c8328a28e2c0d337717cb