### PR TITLE
fix token build path

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 
-const baseDir = path.dirname(new URL(import.meta.url).pathname);
+const baseDir = path.dirname(fileURLToPath(import.meta.url));
 
 interface TokenNode {
   $type?: string;


### PR DESCRIPTION
## Summary
- fix token build path using fileURLToPath

## Testing
- `npm run lint:js`
- `npx --yes tsx scripts/build-tokens.ts`
- `wine /tmp/node-win/node-v20.19.4-win-x64/node.exe node_modules/tsx/dist/cli.mjs scripts/build-tokens.ts`


------
https://chatgpt.com/codex/tasks/task_e_689cced2840083288ffe27985a5634df