### PR TITLE
feat(cli): scaffold index and test files

### DIFF
--- a/packages/capsule-cli/README.md
+++ b/packages/capsule-cli/README.md
@@ -1,0 +1,32 @@
+# Capsule CLI
+
+The Capsule CLI provides utilities for working with Capsule UI.
+
+## Usage
+
+### Scaffold a component
+
+```
+node ./bin/capsule.js new component my-button
+```
+
+This command accepts the component name in any of the following formats:
+
+- `my-button`
+- `my_button`
+- `myButton`
+
+The name is converted to PascalCase (`MyButton`).
+
+The scaffolding generates the following files:
+
+- `MyButton.ts` – component stub
+- `style.ts` – style API stub
+- `index.ts` – re-export of the component
+- `__tests__/MyButton.test.ts` – placeholder test
+
+## Other commands
+
+- `tokens build` – build design tokens
+- `check` – run lint checks
+


### PR DESCRIPTION
## Summary
- convert component names to PascalCase, handling kebab and snake cases
- scaffold index and test files alongside component and style stubs
- document CLI scaffolding outputs

## Testing
- `pnpm lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cd88af678832898389733d0f60704