### PR TITLE
refactor: simplify booking widget theming

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,12 +11,12 @@ Include the widget on a page:
 <booking-widget id="w"></booking-widget>
 ```
 
-Theme it at runtime by changing CSS variables or attributes:
+Theme it at runtime by changing CSS variables or the document's theme attribute:
 
 ```js
 const w = document.getElementById('w');
 w.style.setProperty('--bk-brand', '#ff3b3b');
-w.setAttribute('theme', 'dark');
+document.documentElement.setAttribute('data-theme', 'dark');
 ```
 
 Customize exposed parts safely:

--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -12,9 +12,6 @@ customElements.define("booking-widget", class extends HTMLElement {
           display: block;
           color: var(--bk-text);
         }
-        :host([theme="dark"]) {
-          --bk-text: var(--color-text);
-        }
         @layer base {
           .card {
             padding: 1rem;

--- a/examples/index.html
+++ b/examples/index.html
@@ -18,7 +18,7 @@
       // runtime theming after load
       setTimeout(() => {
         w.style.setProperty('--bk-brand', '#ff3b3b');
-        w.setAttribute('theme', 'dark');
+        document.documentElement.setAttribute('data-theme', 'dark');
       }, 1000);
     </script>
   </body>


### PR DESCRIPTION
## Summary
- rely on document-level `data-theme` tokens in booking widget
- adjust example page and docs to use `data-theme`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cd88989a083289a25414ece40319d