### PR TITLE
Validate token types and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "lint:js": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint": "npm run lint:css && npm run lint:js",
-    "tokens:build": "npx ts-node scripts/build-tokens.ts"
+    "tokens:build": "npx ts-node --compiler-options '{\"module\":\"commonjs\"}' scripts/build-tokens.ts",
+    "test": "node --test"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^8.39.1",

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { promises: fs } = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+
+const root = path.join(__dirname, '..');
+const script = path.join(root, 'scripts', 'build-tokens.ts');
+const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
+
+function runBuild() {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'npx',
+      ['ts-node', '--compiler-options', '{"module":"commonjs"}', script],
+      { cwd: root },
+      (error, stdout, stderr) => {
+        if (error) reject(new Error(stderr.trim()));
+        else resolve(stdout);
+      }
+    );
+  });
+}
+
+test('build tokens validation errors', async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify({ color: { bad: { $type: 'color', $value: 'nope' } } }, null, 2)
+    );
+    await assert.rejects(runBuild(), /invalid color value/);
+
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify({ color: { bad: { $type: 'unknown', $value: '#fff' } } }, null, 2)
+    );
+    await assert.rejects(runBuild(), /Unknown \$type 'unknown'/);
+
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify({ color: { bad: { $type: 'color' } } }, null, 2)
+    );
+    await assert.rejects(runBuild(), /missing \$value/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- validate token $type and $value formats in build script
- report missing values or unknown token types
- add unit tests for build failures on invalid tokens

## Testing
- `npm run lint`
- `npm test`
- `npm run tokens:build`


------
https://chatgpt.com/codex/tasks/task_e_689cd888ecd88328b82d8aebc4e4aaac