### PR TITLE
feat(cli): add tokens watch command

### DIFF
--- a/packages/capsule-cli/README.md
+++ b/packages/capsule-cli/README.md
@@ -28,5 +28,6 @@ The scaffolding generates the following files:
 ## Other commands
 
 - `tokens build` – build design tokens
+- `tokens watch` – rebuild tokens on source changes
 - `check` – run lint checks
 

--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -43,6 +43,13 @@ tokens
     process.exitCode = runCommand('pnpm', ['run', 'tokens:build']);
   });
 
+tokens
+  .command('watch')
+  .description('Watch design tokens and rebuild on changes')
+  .action(() => {
+    process.exitCode = runCommand('pnpm', ['run', 'tokens:watch']);
+  });
+
 program
   .command('check')
   .description('Run lint checks')


### PR DESCRIPTION
## Summary
- add `tokens watch` subcommand to Capsule CLI
- document `tokens watch` in CLI README

## Testing
- `pnpm lint`
- `pnpm capsule tokens watch` *(fails: ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "capsule" not found)*
- `node packages/capsule-cli/bin/capsule.js tokens watch`


------
https://chatgpt.com/codex/tasks/task_e_689ce4583d1483289017df425b53c054