### PR TITLE
feat(cli): validate component name and test scaffolding

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -71,6 +71,13 @@ function runCommand(command, params) {
 
 export async function scaffoldComponent(rawName) {
   try {
+    const validName = /^[a-z0-9_-]+$/i;
+    if (!validName.test(rawName)) {
+      console.error(
+        `Invalid component name "${rawName}". Use only letters, numbers, hyphens, or underscores.`
+      );
+      process.exit(1);
+    }
     const name = toPascalCase(rawName);
     const baseDir = join(process.cwd(), 'packages', 'components', name);
 

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { mkdtemp, rm, access } = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+const { execFile } = require('node:child_process');
+
+const cli = path.join(
+  __dirname,
+  '..',
+  'packages',
+  'capsule-cli',
+  'bin',
+  'capsule.js'
+);
+
+function run(args, options = {}) {
+  return new Promise((resolve) => {
+    execFile('node', [cli, ...args], options, (error, stdout, stderr) => {
+      resolve({
+        code: error && typeof error.code === 'number' ? error.code : 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+test('scaffolds component with valid name', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    const { code } = await run(['new', 'component', 'valid-name'], { cwd: tmp });
+    assert.equal(code, 0);
+    await access(path.join(tmp, 'packages', 'components', 'ValidName'));
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('rejects invalid component name', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    const { code, stderr } = await run(
+      ['new', 'component', 'invalid name!'],
+      { cwd: tmp }
+    );
+    assert.equal(code, 1);
+    assert.match(stderr, /Invalid component name/i);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('fails when component already exists', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    let res = await run(['new', 'component', 'dupe'], { cwd: tmp });
+    assert.equal(res.code, 0);
+    res = await run(['new', 'component', 'dupe'], { cwd: tmp });
+    assert.equal(res.code, 1);
+    assert.match(res.stderr, /already exists/);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+


### PR DESCRIPTION
## Summary
- validate component names before scaffolding
- test CLI scaffolding for valid, invalid, and existing components

## Testing
- `npm run lint`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689ce456f4888328ab384214e5661e4b