### PR TITLE
feat: support more color formats and stable token order

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -17,7 +17,13 @@ function validateToken(name: string, type: string | undefined, value: any) {
 
   const validators: Record<string, Validator> = {
     color: value => {
-      if (typeof value !== 'string' || !/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(value)) {
+      const hex = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+      const rgb = /^rgba?\((\s*\d{1,3}\s*,){2}\s*\d{1,3}(\s*,\s*(0|0?\.\d+|1(?:\.0)?))?\s*\)$/;
+      const hsl = /^hsla?\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%(\s*,\s*(0|0?\.\d+|1(?:\.0)?))?\s*\)$/;
+      if (
+        typeof value !== 'string' ||
+        !(hex.test(value) || rgb.test(value) || hsl.test(value))
+      ) {
         throw new Error(`Token '${name}' has invalid color value '${value}'`);
       }
     },
@@ -64,7 +70,7 @@ async function build() {
   const dist = path.join(root, 'dist');
   await fs.mkdir(dist, { recursive: true });
   const raw = JSON.parse(await fs.readFile(src, 'utf8')) as TokenNode;
-  const tokens = flattenTokens(raw);
+  const tokens = flattenTokens(raw).sort((a, b) => a.name.localeCompare(b.name));
 
   // Gather all theme names across tokens
   const themeNames = new Set<string>();

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -46,3 +46,35 @@ test('build tokens validation errors', async () => {
     await fs.writeFile(tokensPath, original);
   }
 });
+
+test('accepts various color formats and outputs sorted tokens', async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify(
+        {
+          color: {
+            zeta: { $type: 'color', $value: '#11223344' },
+            alpha: { $type: 'color', $value: 'rgb(0,0,0)' },
+            middle: { $type: 'color', $value: 'hsl(0,0%,0%)' }
+          }
+        },
+        null,
+        2
+      )
+    );
+    await runBuild();
+    const css = await fs.readFile(path.join(root, 'dist', 'tokens.css'), 'utf8');
+    assert.match(css, /--color-alpha: rgb\(0,0,0\);/);
+    assert.match(css, /--color-middle: hsl\(0,0%,0%\);/);
+    assert.match(css, /--color-zeta: #11223344;/);
+    const vars = css
+      .split('\n')
+      .filter(line => line.startsWith('  --'))
+      .map(line => line.match(/^\s{2}(--[^:]+):/)[1]);
+    assert.deepEqual(vars, [...vars].sort());
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- extend color validator to accept rgb(), hsl(), and 8-digit hex
- sort flattened tokens alphabetically before generating outputs
- add tests for new color formats and sorted token order

## Testing
- `npm run lint:js`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689ce45409b48328b91468b7b13b4e36