### PR TITLE
Allow negative dimension tokens

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -29,7 +29,10 @@ function validateToken(name: string, type: string | undefined, value: any) {
       }
     },
     dimension: value => {
-      if (typeof value !== 'string' || !/^\d+(?:\.\d+)?(px|rem|em|%)$/.test(value)) {
+      if (
+        typeof value !== 'string' ||
+        !/^-?\d+(?:\.\d+)?(px|rem|em|%)$/.test(value)
+      ) {
         throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
       }
     }

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -93,3 +93,22 @@ test('accepts various color formats and outputs sorted tokens', async () => {
     await fs.writeFile(tokensPath, original);
   }
 });
+
+test('accepts negative dimension values', async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify(
+        { spacing: { neg: { $type: 'dimension', $value: '-4px' } } },
+        null,
+        2
+      )
+    );
+    await runBuild();
+    const css = await fs.readFile(path.join(root, 'dist', 'tokens.css'), 'utf8');
+    assert.match(css, /--spacing-neg: -4px;/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});


### PR DESCRIPTION
## Summary
- support negative values in dimension token validation
- add test for negative dimension tokens

## Testing
- `node --test tests/build-tokens.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1b220e9c83289ffcf7a38c12f9ea