### PR TITLE
chore: deploy example to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy example to GitHub Pages
+
+on:
+  push:
+    branches: ["work"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run tokens:build
+      - run: cp -r dist examples/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: examples
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Booking Widget Demo</title>
-    <link rel="stylesheet" href="../dist/tokens.css">
+    <link rel="stylesheet" href="./dist/tokens.css">
     <script type="module" src="./booking-widget.js"></script>
     <style>
       body { font-family: sans-serif; padding: 2rem; }

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { mkdtemp, rm, access } = require('node:fs/promises');
+const { mkdtemp, rm, access, readFile } = require('node:fs/promises');
 const path = require('node:path');
 const os = require('node:os');
 const { execFile } = require('node:child_process');
@@ -74,7 +74,7 @@ process.argv = originalArgv;
 process.exit = originalExit;
 
 test('scaffoldComponent generates expected files', async () => {
-  const tempDir = await mkdtemp(path.join(tmpdir(), 'capsule-'));
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
   const originalCwd = process.cwd();
   process.chdir(tempDir);
   try {


### PR DESCRIPTION
## Summary
- update example to reference tokens from local dist folder
- add GitHub Actions workflow to publish example to GitHub Pages
- fix scaffold component test imports to satisfy lint

## Testing
- `npm run lint:css`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689d1b577f088328ac9540e83fc9f2e4