### PR TITLE
fix: handle null token values

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -38,7 +38,7 @@ function validateToken(name: string, type: string | undefined, value: any) {
   const validate = validators[type];
   if (!validate) throw new Error(`Unknown $type '${type}' for token '${name}'`);
 
-  if (typeof value === 'object') {
+  if (value !== null && typeof value === 'object') {
     for (const v of Object.values(value)) {
       validate(v);
     }
@@ -51,11 +51,11 @@ function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] =
   for (const [key, val] of Object.entries(obj)) {
     if (key.startsWith('$')) continue;
     const name = [...prefix, key].join('.');
-    if (typeof val === 'object' && '$value' in val) {
+    if (val && typeof val === 'object' && '$value' in val) {
       if (val.$value === undefined) throw new Error(`Token '${name}' is missing $value`);
       validateToken(name, val.$type, val.$value);
       out.push({ name, value: val.$value });
-    } else if (typeof val === 'object') {
+    } else if (val && typeof val === 'object') {
       if ('$type' in val && !('$value' in val)) {
         throw new Error(`Token '${name}' is missing $value`);
       }

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -62,6 +62,19 @@ test('build tokens validation errors', async () => {
   }
 });
 
+test('tokens with null values are handled gracefully', async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify({ color: { bad: { $type: 'color', $value: null } } }, null, 2)
+    );
+    await assert.rejects(runBuild(), /Token schema validation failed/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});
+
 test('accepts various color formats and outputs sorted tokens', async () => {
   const original = await fs.readFile(tokensPath, 'utf8');
   try {


### PR DESCRIPTION
## Summary
- guard against nulls in token validation and flattening
- add regression test for null token values

## Testing
- `node --test`
- `node --test tests/build-tokens.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1b21aa7083289e32de8bd86bc340