### PR TITLE
Normalize PascalCase conversion

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -126,6 +126,9 @@ function toPascalCase(str) {
     .replace(/[-_]+/g, ' ')
     .replace(/([a-z])([A-Z])/g, '$1 $2')
     .split(/\s+/)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .map((w) => {
+      const lower = w.toLowerCase();
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
     .join('');
 }


### PR DESCRIPTION
## Summary
- ensure CLI's toPascalCase lowercases words before capitalizing
- test mixed-case component names are converted to PascalCase
- refactor scaffold-component tests to avoid top-level await import side effects

## Testing
- `node --test`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689d1b22edf88328b69ba189787c1e12