### PR TITLE
feat: expand token validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "typescript": "^5.9.2",
     "chokidar-cli": "^3.0.0",
     "tsx": "^4.20.4",
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "css-tree": "^3.1.0",
+    "@types/css-tree": "^2.3.10"
   },
   "packageManager": "pnpm@10.5.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/css-tree':
+        specifier: ^2.3.10
+        version: 2.3.10
       '@typescript-eslint/parser':
         specifier: ^8.39.1
         version: 8.39.1(eslint@8.57.1)(typescript@5.9.2)
@@ -17,6 +20,9 @@ importers:
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
+      css-tree:
+        specifier: ^3.1.0
+        version: 3.1.0
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
@@ -300,6 +306,9 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/css-tree@2.3.10':
+    resolution: {integrity: sha512-WcaBazJ84RxABvRttQjjFWgTcHvZR9jGr0Y3hccPkHjFyk/a3N8EuxjKr+QfrwjoM5b1yI1Uj1i7EzOAAwBwag==}
+
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
@@ -504,6 +513,10 @@ packages:
 
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   cssesc@3.0.0:
@@ -880,6 +893,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   meow@10.1.5:
     resolution: {integrity: sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==}
@@ -1461,6 +1477,8 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
+  '@types/css-tree@2.3.10': {}
+
   '@types/minimist@1.2.5': {}
 
   '@types/node@24.2.1':
@@ -1677,6 +1695,11 @@ snapshots:
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
+      source-map-js: 1.2.1
+
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
       source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
@@ -2050,6 +2073,8 @@ snapshots:
   mathml-tag-names@2.1.3: {}
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.12.2: {}
 
   meow@10.1.5:
     dependencies:


### PR DESCRIPTION
## Summary
- validate CSS colors and dimensions with css-tree
- accept additional units and color formats like vh/vw/ch and hwb()/lch()/keywords
- test extended token formats and error cases

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689d1fda468c8328845775619c722615