### PR TITLE
Refactor scaffoldComponent return values

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -34,7 +34,8 @@ program
       process.exitCode = 1;
       return;
     }
-    await scaffoldComponent(name);
+    const ok = await scaffoldComponent(name);
+    process.exitCode = ok ? 0 : 1;
   });
 
 const tokens = program.command('tokens').description('Design token utilities');
@@ -90,8 +91,7 @@ export async function scaffoldComponent(rawName) {
       console.error(
         `Invalid component name "${rawName}". Use only letters, numbers, hyphens, or underscores.`
       );
-      process.exitCode = 1;
-      return;
+      return false;
     }
     const name = toPascalCase(rawName);
     const baseDir = join(process.cwd(), 'packages', 'components', name);
@@ -99,8 +99,7 @@ export async function scaffoldComponent(rawName) {
     try {
       await access(baseDir);
       console.error(`Component "${name}" already exists`);
-      process.exitCode = 1;
-      return;
+      return false;
     } catch {
       // directory does not exist; continue
     }
@@ -124,9 +123,10 @@ export async function scaffoldComponent(rawName) {
     await writeFile(indexFile, indexSrc, 'utf8');
     await writeFile(testFile, testSrc, 'utf8');
     console.log(`Scaffolded component at ${baseDir}`);
+    return true;
   } catch (err) {
     console.error('Error scaffolding component:', err);
-    process.exitCode = 1;
+    return false;
   }
 }
 

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -75,13 +75,14 @@ test('fails when component already exists', async () => {
   }
 });
 
-test('scaffoldComponent generates expected files', async () => {
+test('scaffoldComponent returns true and generates expected files', async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
   const originalCwd = process.cwd();
   process.chdir(tempDir);
   try {
     const { scaffoldComponent } = await import('../packages/capsule-cli/bin/capsule.js');
-    await scaffoldComponent('example-component');
+    const result = await scaffoldComponent('example-component');
+    assert.equal(result, true);
     const baseDir = path.join(tempDir, 'packages', 'components', 'ExampleComponent');
     const component = await readFile(path.join(baseDir, 'ExampleComponent.ts'), 'utf8');
     const style = await readFile(path.join(baseDir, 'style.ts'), 'utf8');


### PR DESCRIPTION
## Summary
- Return true/false from `scaffoldComponent` instead of mutating `process.exitCode`
- Set `process.exitCode` from the `capsule new` action based on scaffold success
- Update scaffold component tests for new return behavior

## Testing
- `pnpm run lint`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689de3cd41248328a6445b22a1df7e66