### PR TITLE
feat: support number and font-size tokens

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -36,6 +36,20 @@ function validateToken(name: string, type: string | undefined, value: any) {
       if (!isLength && !isPercent) {
         throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
       }
+    },
+    number: value => {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        throw new Error(`Token '${name}' has invalid number value '${value}'`);
+      }
+    },
+    'font-size': value => {
+      if (typeof value !== 'string') {
+        throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
+      }
+      const match = csstree.lexer.matchProperty('font-size', value);
+      if (match.error) {
+        throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
+      }
     }
   };
 
@@ -106,7 +120,7 @@ async function build() {
   for (const theme of themeNames) {
     themes[theme] = [];
   }
-  const jsonOut: Record<string, Record<string, string>> = {};
+  const jsonOut: Record<string, Record<string, string | number>> = {};
 
   for (const t of tokens) {
     const cssVar = '--' + t.name.replace(/\./g, '-');
@@ -146,7 +160,7 @@ async function build() {
   const dts =
     `export type ThemeName = ${themeUnion};\n` +
     `export type TokenName = ${names};\n` +
-    `export type TokenValues = Record<ThemeName, string>;\n` +
+    `export type TokenValues = Record<ThemeName, string | number>;\n` +
     `export const tokens: Record<TokenName, TokenValues>;\n` +
     `export default tokens;\n`;
   await fs.writeFile(path.join(dist, 'tokens.d.ts'), dts + '\n');

--- a/tokens/token.schema.json
+++ b/tokens/token.schema.json
@@ -15,15 +15,15 @@
       "properties": {
         "$type": {
           "type": "string",
-          "enum": ["color", "dimension"]
+          "enum": ["color", "dimension", "number", "font-size"]
         },
         "$value": {
           "anyOf": [
-            { "type": "string" },
+            { "type": ["string", "number"] },
             {
               "type": "object",
               "minProperties": 1,
-              "additionalProperties": { "type": "string" }
+              "additionalProperties": { "type": ["string", "number"] }
             }
           ]
         }


### PR DESCRIPTION
## Summary
- allow `number` and `font-size` token types in token schema
- validate new token types in build script and include numbers in output types
- test handling of the new token types including validation errors

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_689de3cc34e08328b1089cff86aa2146