### PR TITLE
chore(ci): use pnpm with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
-      - run: npm run lint:css
-      - run: npm run lint:js
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:css
+      - run: pnpm run lint:js


### PR DESCRIPTION
## Summary
- use pnpm with cache in CI workflow

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint:css`
- `pnpm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_689de3cb3a308328b489b62aec67000a