### PR TITLE
Add Node test script and CI test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
       - run: npm install
       - run: npm run lint:css
       - run: npm run lint:js
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint:css": "stylelint \"**/*.{css,scss}\"",
     "lint:js": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint": "npm run lint:css && npm run lint:js",
+    "test": "node --test",
     "tokens:build": "tsx scripts/build-tokens.ts",
     "tokens:watch": "chokidar \"tokens/source/tokens.json\" -c \"pnpm tokens:build\""
   },


### PR DESCRIPTION
## Summary
- add `npm test` script using Node's built-in test runner
- run tests in CI after linting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de3cb37208328b6c74fba8f66882a