### PR TITLE
feat(cli): enforce component name begins with letter

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -86,10 +86,10 @@ function runCommand(command, params) {
 
 export async function scaffoldComponent(rawName) {
   try {
-    const validName = /^[a-z0-9_-]+$/i;
+    const validName = /^[a-z][a-z0-9_-]*$/i;
     if (!validName.test(rawName)) {
       console.error(
-        `Invalid component name "${rawName}". Use only letters, numbers, hyphens, or underscores.`
+        `Invalid component name "${rawName}". Name must start with a letter and may contain only letters, numbers, hyphens, or underscores.`
       );
       return false;
     }

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -62,6 +62,20 @@ test('rejects invalid component name', async () => {
   }
 });
 
+test('rejects component name starting with a number', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    const { code, stderr } = await run(
+      ['new', 'component', '123abc'],
+      { cwd: tmp }
+    );
+    assert.equal(code, 1);
+    assert.match(stderr, /must start with a letter/i);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test('fails when component already exists', async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
   try {


### PR DESCRIPTION
## Summary
- ensure component names start with a letter in CLI scaffolding
- add test rejecting numeric-leading component names

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689e052f179c83289e97c9a38bb91a4a