### PR TITLE
Add explicit button type to booking widget example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ customElements.define("booking-widget", class extends HTMLElement {
           .button{ background: var(--bk-brand); color:white; border:0; padding:.7rem 1rem; border-radius:12px; }
         }
       </style>
-      <button class="button" part="button">Book</button>
+      <button class="button" part="button" type="button">Book</button>
     `;
   }
 });

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,8 @@
 # Booking Widget Example
 
 This directory demonstrates a minimal Capsule widget built with Shadow DOM.
+Its internal action uses a `<button type="button">` element to avoid
+unintended form submissions.
 
 ## Usage
 

--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -33,7 +33,7 @@ customElements.define("booking-widget", class extends HTMLElement {
         }
       </style>
       <div class="card" part="card">
-        <button class="button" part="button" aria-label="Book reservation">Book</button>
+        <button class="button" part="button" type="button" aria-label="Book reservation">Book</button>
       </div>
     `;
   }

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,7 +11,8 @@
   </head>
   <body>
     <h1>Booking Widget Demo</h1>
-    <p>Use Tab to focus the button; it includes an accessible label and focus style.</p>
+    <p>Use Tab to focus the button; it includes an accessible label, a
+    <code>type="button"</code> attribute, and a focus style.</p>
     <booking-widget id="w"></booking-widget>
     <script>
       const w = document.getElementById('w');


### PR DESCRIPTION
## Summary
- add `type="button"` to booking widget button
- document button type in example docs and demo

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689e052c4e948328aac1e344af69ee4a