### PR TITLE
feat: preserve newline style in require-layer

### DIFF
--- a/stylelint/require-layer.js
+++ b/stylelint/require-layer.js
@@ -31,6 +31,20 @@ module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, con
 
     const expected = options.name || 'components';
 
+    const source = root.source && root.source.input && root.source.input.css;
+    let newline = '\n';
+    if (source && source.includes('\r\n')) {
+      newline = '\r\n';
+    } else if (root.raws) {
+      for (const key in root.raws) {
+        const value = root.raws[key];
+        if (typeof value === 'string' && value.includes('\r\n')) {
+          newline = '\r\n';
+          break;
+        }
+      }
+    }
+
     let hasLayer = false;
     root.walkAtRules('layer', (rule) => {
       if (rule.parent !== root) {
@@ -59,11 +73,11 @@ module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, con
         }
 
         if (insertAfter) {
-          insertAfter.after(`\n@layer ${expected};\n`);
+          insertAfter.after(`${newline}@layer ${expected};${newline}`);
         } else {
-          root.prepend(`@layer ${expected};\n`);
+          root.prepend(`@layer ${expected};${newline}`);
           if (root.nodes[1]) {
-            root.nodes[1].raws.before = root.nodes[1].raws.before || '\n';
+            root.nodes[1].raws.before = root.nodes[1].raws.before || newline;
           }
         }
       } else {

--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -46,6 +46,13 @@ test('auto-fixes missing layer after @charset', async () => {
   );
 });
 
+test('preserves CRLF newlines when auto-fixing', async () => {
+  const css = 'a{color:red}\r\n';
+  const result = await lint(css, { fix: true });
+  assert.equal(result.errored, false);
+  assert.equal(result.output, '@layer components;\r\n' + css);
+});
+
 test('supports custom layer name', async () => {
   const result = await lint('a{color:red}', { config: { name: 'custom' } });
   assert.equal(result.errored, true);


### PR DESCRIPTION
## Summary
- detect existing newline style before auto-inserting `@layer`
- keep original newline when fixing missing layer
- add test for CRLF newline preservation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e052b463c8328ba6cbbbc3d65cffc