### PR TITLE
Prefer root raws for newline detection

### DIFF
--- a/stylelint/require-layer.js
+++ b/stylelint/require-layer.js
@@ -33,7 +33,15 @@ module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, con
 
     const source = root.source && root.source.input && root.source.input.css;
     let newline = '\n';
-    if (source && source.includes('\r\n')) {
+    if (root.raws && typeof root.raws.after === 'string' && root.raws.after.length > 0) {
+      newline = root.raws.after.includes('\r\n') ? '\r\n' : '\n';
+    } else if (
+      root.raws &&
+      typeof root.raws.semicolon === 'string' &&
+      root.raws.semicolon.length > 0
+    ) {
+      newline = root.raws.semicolon.includes('\r\n') ? '\r\n' : '\n';
+    } else if (source && source.includes('\r\n')) {
       newline = '\r\n';
     } else if (root.raws) {
       for (const key in root.raws) {

--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -31,10 +31,17 @@ test('passes when layer is present', async () => {
   assert.equal(result.results[0].warnings.length, 0);
 });
 
-test('auto-fixes missing layer', async () => {
+test('auto-fixes file without trailing newline', async () => {
   const result = await lint('a{color:red}', { fix: true });
   assert.equal(result.errored, false);
   assert.equal(result.output, '@layer components;\na{color:red}');
+});
+
+test('auto-fixes and preserves LF newlines', async () => {
+  const css = 'a{color:red}\n';
+  const result = await lint(css, { fix: true });
+  assert.equal(result.errored, false);
+  assert.equal(result.output, '@layer components;\n' + css);
 });
 
 test('auto-fixes missing layer after @charset', async () => {
@@ -46,7 +53,7 @@ test('auto-fixes missing layer after @charset', async () => {
   );
 });
 
-test('preserves CRLF newlines when auto-fixing', async () => {
+test('auto-fixes and preserves CRLF newlines', async () => {
   const css = 'a{color:red}\r\n';
   const result = await lint(css, { fix: true });
   assert.equal(result.errored, false);


### PR DESCRIPTION
## Summary
- detect newline style using `root.raws.after` or `root.raws.semicolon` before scanning entire source
- test autofix behavior for LF, CRLF, and files without trailing newlines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f4c081d408328927e1eaae7e22271