### PR TITLE
feat(cli): use async command parsing

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -65,7 +65,7 @@ if (
   import.meta.url === process.argv[1] ||
   import.meta.url === pathToFileURL(process.argv[1]).href
 )
-  program.parse(process.argv);
+  await program.parseAsync(process.argv);
 
 function runCommand(command, params) {
   try {


### PR DESCRIPTION
## Summary
- switch CLI to `parseAsync` for asynchronous command support

## Testing
- `node packages/capsule-cli/bin/capsule.js tokens build`
- `node packages/capsule-cli/bin/capsule.js check`
- `node packages/capsule-cli/bin/capsule.js new invalid foo` *(fails as expected)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4c025b8c8328a0424a4eab4478a1