### PR TITLE
feat(cli): tighten component name validation

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -109,10 +109,10 @@ function runCommand(command, params) {
 
 export async function scaffoldComponent(rawName) {
   try {
-    const validName = /^[a-z][a-z0-9_-]*$/i;
+    const validName = /^[a-z](?:[a-z0-9]*(?:[-_][a-z0-9]+)*)$/i;
     if (!validName.test(rawName)) {
       console.error(
-        `Invalid component name "${rawName}". Name must start with a letter and may contain only letters, numbers, hyphens, or underscores.`
+        `Invalid component name "${rawName}". Name must start with a letter, may contain letters, numbers, hyphens, or underscores, and cannot have leading/trailing separators or consecutive separators.`
       );
       return false;
     }

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -76,6 +76,34 @@ test('rejects component name starting with a number', async () => {
   }
 });
 
+test('rejects component name with trailing separator', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    const { code, stderr } = await run(
+      ['new', 'component', 'invalid-'],
+      { cwd: tmp }
+    );
+    assert.equal(code, 1);
+    assert.match(stderr, /Invalid component name/i);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('rejects component name with repeated separators', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+  try {
+    const { code, stderr } = await run(
+      ['new', 'component', 'invalid__name'],
+      { cwd: tmp }
+    );
+    assert.equal(code, 1);
+    assert.match(stderr, /Invalid component name/i);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test('fails when component already exists', async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
   try {


### PR DESCRIPTION
## Summary
- enforce stricter component name validation in Capsule CLI
- add tests for trailing and repeated separators

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689faf67e844832896a388e255880c7b