### PR TITLE
Enforce lowercase token keys

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -68,10 +68,10 @@ function validateToken(name: string, type: string | undefined, value: any) {
 function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] = []): FlatToken[] {
   for (const [key, val] of Object.entries(obj)) {
     if (key.startsWith('$')) continue;
-    if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+    if (!/^[a-z0-9_-]+$/.test(key)) {
       const fullName = [...prefix, key].join('.');
       throw new Error(
-        `Invalid token key '${fullName}'. Keys may only include letters, digits, hyphen, and underscore.`
+        `Invalid token key '${fullName}'. Keys may only include lowercase letters, digits, hyphen, and underscore.`
       );
     }
     const name = [...prefix, key].join('.');

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -75,6 +75,19 @@ test('rejects invalid token names', { concurrency: false }, async () => {
   }
 });
 
+test('rejects uppercase token names', { concurrency: false }, async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify({ Color: { ok: { $type: 'color', $value: '#fff' } } }, null, 2)
+    );
+    await assert.rejects(runBuild(), /Invalid token key 'Color'/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});
+
 test('accepts valid token names', { concurrency: false }, async () => {
   const original = await fs.readFile(tokensPath, 'utf8');
   try {

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -1,0 +1,16 @@
+# Tokens
+
+Design tokens for Capsule UI.
+
+Token keys must be lowercase and may only contain letters, digits, hyphen (`-`), and underscore (`_`).
+
+Example:
+
+```json
+{
+  "color": {
+    "brand-primary": { "$type": "color", "$value": "#fff" }
+  }
+}
+```
+

--- a/tokens/token.schema.json
+++ b/tokens/token.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Capsule UI Tokens Schema",
+  "description": "Token keys must be lowercase letters, digits, hyphen, and underscore.",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" }


### PR DESCRIPTION
## Summary
- enforce lowercase-only token names in build script
- document lowercase naming requirement for design tokens
- test rejection of uppercase token keys

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689faf6d9bec832891fb3ae86c7c0b05