### PR TITLE
Fix token build warnings and sample tokens

### DIFF
--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,18 +1,18 @@
 @layer components;
 :root{
   --color-background: #ffffff;
-  --color-text: #0f172a;
-  --color-brand: #4f46e5;
-  --spacing-sm: 4px;
-  --spacing-md: 8px;
+  --color-brand: #ff0000;
+  --color-text: #000000;
   --spacing-lg: 16px;
+  --spacing-md: 8px;
+  --spacing-sm: 4px;
 }
 
 [data-theme="dark"]{
-  --color-background: #0f172a;
-  --color-text: #e6e8ef;
-  --color-brand: #818cf8;
-  --spacing-sm: 4px;
-  --spacing-md: 8px;
+  --color-background: #000000;
+  --color-brand: #00ff00;
+  --color-text: #ffffff;
   --spacing-lg: 16px;
+  --spacing-md: 8px;
+  --spacing-sm: 4px;
 }

--- a/dist/tokens.d.ts
+++ b/dist/tokens.d.ts
@@ -1,6 +1,6 @@
 export type ThemeName = 'light' | 'dark';
-export type TokenName = '--color-background' | '--color-text' | '--color-brand' | '--spacing-sm' | '--spacing-md' | '--spacing-lg';
-export type TokenValues = Record<ThemeName, string>;
+export type TokenName = '--color-background' | '--color-brand' | '--color-text' | '--spacing-lg' | '--spacing-md' | '--spacing-sm';
+export type TokenValues = Record<ThemeName, string | number>;
 export const tokens: Record<TokenName, TokenValues>;
 export default tokens;
 

--- a/dist/tokens.json
+++ b/dist/tokens.json
@@ -1,26 +1,26 @@
 {
   "--color-background": {
     "light": "#ffffff",
-    "dark": "#0f172a"
-  },
-  "--color-text": {
-    "light": "#0f172a",
-    "dark": "#e6e8ef"
+    "dark": "#000000"
   },
   "--color-brand": {
-    "light": "#4f46e5",
-    "dark": "#818cf8"
+    "light": "#ff0000",
+    "dark": "#00ff00"
   },
-  "--spacing-sm": {
-    "light": "4px",
-    "dark": "4px"
+  "--color-text": {
+    "light": "#000000",
+    "dark": "#ffffff"
+  },
+  "--spacing-lg": {
+    "light": "16px",
+    "dark": "16px"
   },
   "--spacing-md": {
     "light": "8px",
     "dark": "8px"
   },
-  "--spacing-lg": {
-    "light": "16px",
-    "dark": "16px"
+  "--spacing-sm": {
+    "light": "4px",
+    "dark": "4px"
   }
 }

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -99,7 +99,7 @@ async function build() {
   // Validate source tokens against the JSON schema before further processing
   const schemaPath = path.join(root, 'tokens', 'token.schema.json');
   const schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
-  const ajv = new Ajv({ allErrors: true });
+  const ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
   const validate = ajv.compile(schema);
   if (!validate(raw)) {
     const msg = (validate.errors || [])

--- a/tokens/source/tokens.json
+++ b/tokens/source/tokens.json
@@ -1,26 +1,16 @@
 {
-  "$schema": "../token.schema.json",
   "color": {
     "background": {
       "$type": "color",
-      "$value": {
-        "light": "#ffffff",
-        "dark": "#0f172a"
-      }
+      "$value": { "light": "#ffffff", "dark": "#000000" }
     },
     "text": {
       "$type": "color",
-      "$value": {
-        "light": "#0f172a",
-        "dark": "#e6e8ef"
-      }
+      "$value": { "light": "#000000", "dark": "#ffffff" }
     },
     "brand": {
       "$type": "color",
-      "$value": {
-        "light": "#4f46e5",
-        "dark": "#818cf8"
-      }
+      "$value": { "light": "#ff0000", "dark": "#00ff00" }
     }
   },
   "spacing": {


### PR DESCRIPTION
## Summary
- allow union type schemas in token builder to eliminate Ajv strict-mode warnings
- replace placeholder tokens with valid themed examples and regenerate dist outputs

## Testing
- `pnpm tokens:build`
- `pnpm lint`
- `pnpm test --test-reporter=spec`


------
https://chatgpt.com/codex/tasks/task_e_689fb1ba3ba48328b47a34bec405e0d3