### PR TITLE
refactor: centralize line ending detection

### DIFF
--- a/stylelint/require-layer.js
+++ b/stylelint/require-layer.js
@@ -16,6 +16,17 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
   expected: (name) => `Expected '@layer ${name}' declaration.`,
 });
 
+function getLineEnding(root) {
+  const css = root && root.source && root.source.input && root.source.input.css;
+  if (
+    stylelint.utils &&
+    typeof stylelint.utils.getLineEnding === 'function'
+  ) {
+    return stylelint.utils.getLineEnding(css);
+  }
+  return css && css.includes('\r\n') ? '\r\n' : '\n';
+}
+
 module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, context) {
   return (root, result) => {
     const validOptions = stylelint.utils.validateOptions(result, ruleName, {
@@ -30,28 +41,7 @@ module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, con
     }
 
     const expected = options.name || 'components';
-
-    const source = root.source && root.source.input && root.source.input.css;
-    let newline = '\n';
-    if (root.raws && typeof root.raws.after === 'string' && root.raws.after.length > 0) {
-      newline = root.raws.after.includes('\r\n') ? '\r\n' : '\n';
-    } else if (
-      root.raws &&
-      typeof root.raws.semicolon === 'string' &&
-      root.raws.semicolon.length > 0
-    ) {
-      newline = root.raws.semicolon.includes('\r\n') ? '\r\n' : '\n';
-    } else if (source && source.includes('\r\n')) {
-      newline = '\r\n';
-    } else if (root.raws) {
-      for (const key in root.raws) {
-        const value = root.raws[key];
-        if (typeof value === 'string' && value.includes('\r\n')) {
-          newline = '\r\n';
-          break;
-        }
-      }
-    }
+    const newline = getLineEnding(root);
 
     let hasLayer = false;
     root.walkAtRules('layer', (rule) => {

--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -37,12 +37,17 @@ test('auto-fixes file without trailing newline', async () => {
   assert.equal(result.output, '@layer components;\na{color:red}');
 });
 
-test('auto-fixes and preserves LF newlines', async () => {
-  const css = 'a{color:red}\n';
-  const result = await lint(css, { fix: true });
-  assert.equal(result.errored, false);
-  assert.equal(result.output, '@layer components;\n' + css);
-});
+for (const [name, newline] of [
+  ['LF', '\n'],
+  ['CRLF', '\r\n'],
+]) {
+  test(`auto-fixes and preserves ${name} newlines`, async () => {
+    const css = `a{color:red}${newline}`;
+    const result = await lint(css, { fix: true });
+    assert.equal(result.errored, false);
+    assert.equal(result.output, `@layer components;${newline}` + css);
+  });
+}
 
 test('auto-fixes missing layer after @charset', async () => {
   const result = await lint('@charset "UTF-8";\na{color:red}', { fix: true });
@@ -51,13 +56,6 @@ test('auto-fixes missing layer after @charset', async () => {
     result.output,
     '@charset "UTF-8";\n@layer components;\na{color:red}'
   );
-});
-
-test('auto-fixes and preserves CRLF newlines', async () => {
-  const css = 'a{color:red}\r\n';
-  const result = await lint(css, { fix: true });
-  assert.equal(result.errored, false);
-  assert.equal(result.output, '@layer components;\r\n' + css);
 });
 
 test('supports custom layer name', async () => {


### PR DESCRIPTION
## Summary
- factor out line-ending detection to a helper that uses `stylelint.utils.getLineEnding` when available or falls back to the source CSS
- simplify `require-layer` rule by relying on the helper
- parameterize tests to verify fixes preserve LF and CRLF line endings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f750d9508328a4c2a1ec3f58eed8