### PR TITLE
chore: enforce Node 18 requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "css-tree": "^3.1.0",
     "@types/css-tree": "^2.3.10"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "packageManager": "pnpm@10.5.2"
 }

--- a/packages/capsule-cli/package.json
+++ b/packages/capsule-cli/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "commander": "^14.0.0"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "packageManager": "pnpm@10.5.2"
 }


### PR DESCRIPTION
## Summary
- require Node >=18 in root and CLI package
- enforce engine requirement via `.npmrc`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f74f7c908328b13dde09025464f2