### PR TITLE
feat: allow multiple required layers

### DIFF
--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -74,6 +74,23 @@ test('supports custom layer name', async () => {
   assert.equal(fixed.output, '@layer custom;\na{color:red}');
 });
 
+test('passes when any configured layer name is present', async () => {
+  const result = await lint('@layer utilities;\na{color:red}', {
+    config: { names: ['components', 'utilities'] },
+  });
+  assert.equal(result.errored, false);
+  assert.equal(result.results[0].warnings.length, 0);
+});
+
+test('auto-fixes using first configured layer name', async () => {
+  const result = await lint('a{color:red}', {
+    fix: true,
+    config: { names: ['utilities', 'components'] },
+  });
+  assert.equal(result.errored, false);
+  assert.equal(result.output, '@layer utilities;\na{color:red}');
+});
+
 test('passes when layer is comma-separated', async () => {
   const result = await lint('@layer base, components;\na{color:red}');
   assert.equal(result.errored, false);


### PR DESCRIPTION
## Summary
- allow `capsule-ui/require-layer` to accept multiple layer names
- document new option in JSDoc
- test rule with multiple allowed layer names

## Testing
- `pnpm test tests/require-layer.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a268fbfb4c832882b92d7c3a9203e0