### PR TITLE
feat: add font-weight and duration token types

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -50,6 +50,24 @@ function validateToken(name: string, type: string | undefined, value: any) {
       if (match.error) {
         throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
       }
+    },
+    'font-weight': value => {
+      if (typeof value !== 'string' && typeof value !== 'number') {
+        throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
+      }
+      const match = csstree.lexer.matchProperty('font-weight', String(value));
+      if (match.error) {
+        throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
+      }
+    },
+    duration: value => {
+      if (typeof value !== 'string') {
+        throw new Error(`Token '${name}' has invalid duration value '${value}'`);
+      }
+      const isTime = csstree.lexer.matchType('time', value).error === null;
+      if (!isTime) {
+        throw new Error(`Token '${name}' has invalid duration value '${value}'`);
+      }
     }
   };
 

--- a/tokens/token.schema.json
+++ b/tokens/token.schema.json
@@ -16,7 +16,14 @@
       "properties": {
         "$type": {
           "type": "string",
-          "enum": ["color", "dimension", "number", "font-size"]
+          "enum": [
+            "color",
+            "dimension",
+            "number",
+            "font-size",
+            "font-weight",
+            "duration"
+          ]
         },
         "$value": {
           "anyOf": [


### PR DESCRIPTION
## Summary
- support `font-weight` and `duration` token types in schema and builder
- validate new token types in build script
- test font-weight and duration token handling

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a268fa23e4832881db2a2696903148