### PR TITLE
refactor: resolve build token paths from script

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -1,7 +1,10 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
 import * as csstree from 'css-tree';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 interface TokenNode {
   $type?: string;
@@ -90,7 +93,6 @@ function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] =
 }
 
 async function build() {
-  const root = process.cwd();
   const src = path.join(root, 'tokens', 'source', 'tokens.json');
   const dist = path.join(root, 'dist');
   await fs.mkdir(dist, { recursive: true });

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -12,8 +12,8 @@ function runBuild() {
   return new Promise((resolve, reject) => {
     execFile(
       'npx',
-      ['ts-node', '--compiler-options', '{"module":"commonjs"}', script],
-      { cwd: root },
+      ['tsx', script],
+      { cwd: __dirname },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim()));
         else resolve(stdout);


### PR DESCRIPTION
## Summary
- resolve repository root in build-tokens script via `import.meta.url`
- execute build tokens tests using `tsx` from tests directory

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a268f763708328b940c8f54cc52631