### PR TITLE
build: output tokens js module

### DIFF
--- a/dist/tokens.js
+++ b/dist/tokens.js
@@ -1,0 +1,27 @@
+export const tokens = {
+  "--color-background": {
+    "light": "#ffffff",
+    "dark": "#000000"
+  },
+  "--color-brand": {
+    "light": "#ff0000",
+    "dark": "#00ff00"
+  },
+  "--color-text": {
+    "light": "#000000",
+    "dark": "#ffffff"
+  },
+  "--spacing-lg": {
+    "light": "16px",
+    "dark": "16px"
+  },
+  "--spacing-md": {
+    "light": "8px",
+    "dark": "8px"
+  },
+  "--spacing-sm": {
+    "light": "4px",
+    "dark": "4px"
+  }
+};
+export default tokens;

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -157,6 +157,11 @@ async function build() {
     JSON.stringify(jsonOut, null, 2) + '\n'
   );
 
+  const js =
+    `export const tokens = ${JSON.stringify(jsonOut, null, 2)};\n` +
+    `export default tokens;\n`;
+  await fs.writeFile(path.join(dist, 'tokens.js'), js);
+
   const names = Object.keys(jsonOut)
     .map(n => `'${n}'`)
     .join(' | ');

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -280,22 +280,45 @@ test('rejects invalid number and font-size values', { concurrency: false }, asyn
   }
 });
 
-test('generates type declarations for tokens', async () => {
-  await runBuild();
-  const dts = await fs.readFile(path.join(root, 'dist', 'tokens.d.ts'), 'utf8');
+test('generates type declarations for tokens', { concurrency: false }, async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(tokensPath, original);
+    await runBuild();
+    const dts = await fs.readFile(path.join(root, 'dist', 'tokens.d.ts'), 'utf8');
 
-  assert.match(dts, /export type TokenName/);
-  for (const name of [
-    '--color-background',
-    '--color-text',
-    '--color-brand',
-    '--spacing-sm',
-    '--spacing-md',
-    '--spacing-lg'
-  ]) {
-    assert.match(dts, new RegExp(name));
+    assert.match(dts, /export type TokenName/);
+    for (const name of [
+      '--color-background',
+      '--color-text',
+      '--color-brand',
+      '--spacing-sm',
+      '--spacing-md',
+      '--spacing-lg'
+    ]) {
+      assert.match(dts, new RegExp(name));
+    }
+
+    assert.match(dts, /export type ThemeName = 'light' \| 'dark';/);
+    assert.match(dts, /export type TokenValues = Record<ThemeName, string \| number>;/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
   }
+});
 
-  assert.match(dts, /export type ThemeName = 'light' \| 'dark';/);
-  assert.match(dts, /export type TokenValues = Record<ThemeName, string \| number>;/);
+test('generates JavaScript module for tokens', { concurrency: false }, async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(tokensPath, original);
+    await runBuild();
+    const js = await fs.readFile(path.join(root, 'dist', 'tokens.js'), 'utf8');
+    assert.match(js, /export const tokens/);
+    const mod = await import('../dist/tokens.js');
+    assert.deepEqual(mod.default['--color-background'], {
+      light: '#ffffff',
+      dark: '#000000',
+    });
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
 });

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -14,3 +14,16 @@ Example:
 }
 ```
 
+Run `pnpm tokens:build` to generate token artifacts in `dist/`:
+
+- `tokens.css` - CSS custom properties for each token.
+- `tokens.json` - token values as JSON.
+- `tokens.js` - JavaScript module exporting the token map.
+- `tokens.d.ts` - TypeScript declarations for the token map.
+
+Example import:
+
+```js
+import tokens from '../dist/tokens.js';
+```
+


### PR DESCRIPTION
## Summary
- emit `dist/tokens.js` alongside existing token artifacts
- document importing the token map from the generated JS module
- add tests covering the JS module generation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a268fb05c08328bfa7882dff626fd2