### PR TITLE
Validate theme completeness for design tokens

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -141,6 +141,17 @@ async function build() {
   }
   if (themeNames.size === 0) themeNames.add('light');
 
+  // Ensure every token with theme-specific values defines all themes
+  for (const t of tokens) {
+    if (typeof t.value === 'object') {
+      for (const theme of themeNames) {
+        if (!(theme in t.value)) {
+          throw new Error(`Token '${t.name}' is missing theme '${theme}'`);
+        }
+      }
+    }
+  }
+
   // Prepare containers for CSS and JSON outputs
   const themes: Record<string, string[]> = {};
   for (const theme of themeNames) {

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -62,6 +62,31 @@ test('build tokens validation errors', { concurrency: false }, async () => {
   }
 });
 
+test('rejects tokens missing theme values', { concurrency: false }, async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify(
+        {
+          color: {
+            background: { $type: 'color', $value: { light: '#fff', dark: '#000' } },
+            incomplete: { $type: 'color', $value: { light: '#fff' } }
+          }
+        },
+        null,
+        2
+      )
+    );
+    await assert.rejects(
+      runBuild(),
+      /Token 'color\.incomplete' is missing theme 'dark'/
+    );
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});
+
 test('rejects invalid token names', { concurrency: false }, async () => {
   const original = await fs.readFile(tokensPath, 'utf8');
   try {


### PR DESCRIPTION
## Summary
- ensure every token with theme-specific values defines all themes
- add regression test for missing theme keys

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c13536c8832891dbad7e9e011d32