### PR TITLE
fix: preserve top comments in require-layer autofix

### DIFF
--- a/stylelint/require-layer.js
+++ b/stylelint/require-layer.js
@@ -75,7 +75,10 @@ module.exports = stylelint.createPlugin(ruleName, function (options = {}, _, con
         const skip = new Set(['charset', 'import', 'namespace']);
 
         for (const node of root.nodes || []) {
-          if (node.type === 'atrule' && skip.has(node.name)) {
+          if (
+            node.type === 'comment' ||
+            (node.type === 'atrule' && skip.has(node.name))
+          ) {
             insertAfter = node;
             continue;
           }

--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -58,6 +58,26 @@ test('auto-fixes missing layer after @charset', async () => {
   );
 });
 
+test('auto-fixes after top-level comments', async () => {
+  const css = '/* theme */\n/* comment */\na{color:red}';
+  const result = await lint(css, { fix: true });
+  assert.equal(result.errored, false);
+  assert.equal(
+    result.output,
+    '/* theme */\n/* comment */\n@layer components;\na{color:red}'
+  );
+});
+
+test('auto-fixes after comments and existing @charset', async () => {
+  const css = '/* theme */\n@charset "UTF-8";\na{color:red}';
+  const result = await lint(css, { fix: true });
+  assert.equal(result.errored, false);
+  assert.equal(
+    result.output,
+    '/* theme */\n@charset "UTF-8";\n@layer components;\na{color:red}'
+  );
+});
+
 test('supports custom layer name', async () => {
   const result = await lint('a{color:red}', { config: { name: 'custom' } });
   assert.equal(result.errored, true);


### PR DESCRIPTION
## Summary
- treat leading comments as skippable when inserting required @layer
- test autofix behavior with top-level comments

## Testing
- `npx eslint stylelint/require-layer.js tests/require-layer.test.js`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c13390108328b0db80a578dc85ed