### PR TITLE
refactor token validators

### DIFF
--- a/scripts/token-validators.ts
+++ b/scripts/token-validators.ts
@@ -1,0 +1,59 @@
+import * as csstree from 'css-tree';
+
+/* eslint-disable no-unused-vars */
+export type Validator = (name: string, value: any) => void;
+/* eslint-enable no-unused-vars */
+
+export const validators: Record<string, Validator> = {
+  color: (name, value) => {
+    if (typeof value !== 'string') {
+      throw new Error(`Token '${name}' has invalid color value '${value}'`);
+    }
+    const match = csstree.lexer.matchProperty('color', value);
+    if (match.error) {
+      throw new Error(`Token '${name}' has invalid color value '${value}'`);
+    }
+  },
+  dimension: (name, value) => {
+    if (typeof value !== 'string') {
+      throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
+    }
+    const isLength = csstree.lexer.matchType('length', value).error === null;
+    const isPercent = csstree.lexer.matchType('percentage', value).error === null;
+    if (!isLength && !isPercent) {
+      throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
+    }
+  },
+  number: (name, value) => {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      throw new Error(`Token '${name}' has invalid number value '${value}'`);
+    }
+  },
+  'font-size': (name, value) => {
+    if (typeof value !== 'string') {
+      throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
+    }
+    const match = csstree.lexer.matchProperty('font-size', value);
+    if (match.error) {
+      throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
+    }
+  },
+  'font-weight': (name, value) => {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
+    }
+    const match = csstree.lexer.matchProperty('font-weight', String(value));
+    if (match.error) {
+      throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
+    }
+  },
+  duration: (name, value) => {
+    if (typeof value !== 'string') {
+      throw new Error(`Token '${name}' has invalid duration value '${value}'`);
+    }
+    const isTime = csstree.lexer.matchType('time', value).error === null;
+    if (!isTime) {
+      throw new Error(`Token '${name}' has invalid duration value '${value}'`);
+    }
+  }
+};

--- a/tests/token-validators.test.js
+++ b/tests/token-validators.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+
+const { validators } = require('../scripts/token-validators.ts');
+
+function expectPass(fn) {
+  assert.doesNotThrow(fn);
+}
+
+function expectFail(fn, msg) {
+  assert.throws(fn, msg);
+}
+
+test('color validator', () => {
+  expectPass(() => validators.color('color', '#fff'));
+  expectPass(() => validators.color('color', 'rgb(0,0,0)'));
+  expectFail(() => validators.color('color', 'nope'), /invalid color value/);
+});
+
+test('dimension validator', () => {
+  expectPass(() => validators.dimension('dim', '10px'));
+  expectPass(() => validators.dimension('dim', '50%'));
+  expectFail(() => validators.dimension('dim', '10qq'), /invalid dimension value/);
+});
+
+test('number validator', () => {
+  expectPass(() => validators.number('num', 5));
+  expectFail(() => validators.number('num', '5'), /invalid number value/);
+});
+
+test('font-size validator', () => {
+  expectPass(() => validators['font-size']('size', '16px'));
+  expectFail(() => validators['font-size']('size', 'huge'), /invalid font-size value/);
+});
+
+test('font-weight validator', () => {
+  expectPass(() => validators['font-weight']('weight', 700));
+  expectPass(() => validators['font-weight']('weight', 'bold'));
+  expectFail(() => validators['font-weight']('weight', 'heavy'), /invalid font-weight value/);
+});
+
+test('duration validator', () => {
+  expectPass(() => validators.duration('dur', '200ms'));
+  expectFail(() => validators.duration('dur', 'fast'), /invalid duration value/);
+});


### PR DESCRIPTION
## Summary
- extract token validators into reusable module
- use shared validators in token build script
- add unit tests for each validator

## Testing
- `pnpm lint:js`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c1392d9c83289cef3922e8a6eb00