### PR TITLE
feat: detect duplicate tokens

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -86,7 +86,12 @@ function validateToken(name: string, type: string | undefined, value: any) {
   }
 }
 
-function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] = []): FlatToken[] {
+function flattenTokens(
+  obj: TokenNode,
+  prefix: string[] = [],
+  out: FlatToken[] = [],
+  seen: Set<string> = new Set()
+): FlatToken[] {
   for (const [key, val] of Object.entries(obj)) {
     if (key.startsWith('$')) continue;
     if (!/^[a-z0-9_-]+$/.test(key)) {
@@ -98,13 +103,18 @@ function flattenTokens(obj: TokenNode, prefix: string[] = [], out: FlatToken[] =
     const name = [...prefix, key].join('.');
     if (val && typeof val === 'object' && '$value' in val) {
       if (val.$value === undefined) throw new Error(`Token '${name}' is missing $value`);
+      const nameKey = name.replace(/\./g, '-');
+      if (seen.has(nameKey)) {
+        throw new Error(`Duplicate token name '${nameKey}'`);
+      }
+      seen.add(nameKey);
       validateToken(name, val.$type, val.$value);
       out.push({ name, value: val.$value });
     } else if (val && typeof val === 'object') {
       if ('$type' in val && !('$value' in val)) {
         throw new Error(`Token '${name}' is missing $value`);
       }
-      flattenTokens(val, [...prefix, key], out);
+      flattenTokens(val, [...prefix, key], out, seen);
     }
   }
   return out;

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -88,6 +88,26 @@ test('rejects uppercase token names', { concurrency: false }, async () => {
   }
 });
 
+test('rejects duplicate token names', { concurrency: false }, async () => {
+  const original = await fs.readFile(tokensPath, 'utf8');
+  try {
+    await fs.writeFile(
+      tokensPath,
+      JSON.stringify(
+        {
+          'color-background': { $type: 'color', $value: '#fff' },
+          color: { background: { $type: 'color', $value: '#000' } }
+        },
+        null,
+        2
+      )
+    );
+    await assert.rejects(runBuild(), /Duplicate token name 'color-background'/);
+  } finally {
+    await fs.writeFile(tokensPath, original);
+  }
+});
+
 test('accepts valid token names', { concurrency: false }, async () => {
   const original = await fs.readFile(tokensPath, 'utf8');
   try {


### PR DESCRIPTION
## Summary
- prevent duplicate token names when flattening tokens
- add regression test for duplicate names

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3c13bd55c832888e526774e85870a