### PR TITLE
refactor: use shared token validators

### DIFF
--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -2,7 +2,8 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
-import * as csstree from 'css-tree';
+import { validators } from './token-validators.js';
+import type { Validator } from './token-validators.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -12,76 +13,18 @@ interface TokenNode {
   [key: string]: any;
 }
 
-/* eslint-disable no-unused-vars */
-type Validator = (value: any) => void;
-/* eslint-enable no-unused-vars */
-
 function validateToken(name: string, type: string | undefined, value: any) {
   if (!type) throw new Error(`Token '${name}' is missing $type`);
 
-  const validators: Record<string, Validator> = {
-    color: value => {
-      if (typeof value !== 'string') {
-        throw new Error(`Token '${name}' has invalid color value '${value}'`);
-      }
-      const match = csstree.lexer.matchProperty('color', value);
-      if (match.error) {
-        throw new Error(`Token '${name}' has invalid color value '${value}'`);
-      }
-    },
-    dimension: value => {
-      if (typeof value !== 'string') {
-        throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
-      }
-      const isLength = csstree.lexer.matchType('length', value).error === null;
-      const isPercent = csstree.lexer.matchType('percentage', value).error === null;
-      if (!isLength && !isPercent) {
-        throw new Error(`Token '${name}' has invalid dimension value '${value}'`);
-      }
-    },
-    number: value => {
-      if (typeof value !== 'number' || Number.isNaN(value)) {
-        throw new Error(`Token '${name}' has invalid number value '${value}'`);
-      }
-    },
-    'font-size': value => {
-      if (typeof value !== 'string') {
-        throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
-      }
-      const match = csstree.lexer.matchProperty('font-size', value);
-      if (match.error) {
-        throw new Error(`Token '${name}' has invalid font-size value '${value}'`);
-      }
-    },
-    'font-weight': value => {
-      if (typeof value !== 'string' && typeof value !== 'number') {
-        throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
-      }
-      const match = csstree.lexer.matchProperty('font-weight', String(value));
-      if (match.error) {
-        throw new Error(`Token '${name}' has invalid font-weight value '${value}'`);
-      }
-    },
-    duration: value => {
-      if (typeof value !== 'string') {
-        throw new Error(`Token '${name}' has invalid duration value '${value}'`);
-      }
-      const isTime = csstree.lexer.matchType('time', value).error === null;
-      if (!isTime) {
-        throw new Error(`Token '${name}' has invalid duration value '${value}'`);
-      }
-    }
-  };
-
-  const validate = validators[type];
+  const validate: Validator | undefined = validators[type];
   if (!validate) throw new Error(`Unknown $type '${type}' for token '${name}'`);
 
   if (value !== null && typeof value === 'object') {
     for (const v of Object.values(value)) {
-      validate(v);
+      validate(name, v);
     }
   } else {
-    validate(value);
+    validate(name, value);
   }
 }
 


### PR DESCRIPTION
## Summary
- import shared token validators in `validate-tokens` script
- remove duplicated validator logic and local type

## Testing
- `pnpm exec eslint scripts/validate-tokens.ts scripts/token-validators.ts`
- `pnpm test`
- `pnpm tokens:validate`


------
https://chatgpt.com/codex/tasks/task_e_68a499576d748328a1e3f737394619d0