### PR TITLE
refactor: centralize TokenNode type for scripts

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -3,14 +3,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
 import { validators } from './token-validators.js';
+import type { TokenNode } from './token-types.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-
-interface TokenNode {
-  $type?: string;
-  $value?: any;
-  [key: string]: any;
-}
 
 /* eslint-disable no-unused-vars */
 type FlatToken = { name: string; value: any };

--- a/scripts/token-types.ts
+++ b/scripts/token-types.ts
@@ -1,0 +1,5 @@
+export interface TokenNode {
+  $type?: string;
+  $value?: any;
+  [key: string]: any;
+}

--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -3,14 +3,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
 import * as csstree from 'css-tree';
+import type { TokenNode } from './token-types.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-
-interface TokenNode {
-  $type?: string;
-  $value?: any;
-  [key: string]: any;
-}
 
 /* eslint-disable no-unused-vars */
 type Validator = (value: any) => void;


### PR DESCRIPTION
## Summary
- add shared `TokenNode` interface for scripts
- import `TokenNode` from shared module in build/validate token scripts

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm tokens:validate`
- `pnpm tokens:build`


------
https://chatgpt.com/codex/tasks/task_e_68a49958a9cc83288dbf678d2732926c