### PR TITLE
refactor: remove duplicate TokenNode interface

### DIFF
--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -2,7 +2,6 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
-import * as csstree from 'css-tree';
 import type { TokenNode } from './token-types.js';
 import { validators } from './token-validators.js';
 
@@ -11,12 +10,6 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 /* eslint-disable no-unused-vars */
 type Validator = (value: any) => void;
 /* eslint-enable no-unused-vars */
-
-interface TokenNode {
-  $type?: string;
-  $value?: any;
-  [key: string]: any;
-}
 
 function validateToken(name: string, type: string | undefined, value: any) {
   if (!type) throw new Error(`Token '${name}' is missing $type`);


### PR DESCRIPTION
## Summary
- remove redundant TokenNode interface definition from token validator

## Testing
- `pnpm test`
- `pnpm run tokens:validate`
- `pnpm exec eslint scripts/validate-tokens.ts`
- `pnpm run lint` *(fails: tests/build-tokens.test.js 224:23 error no-regex-spaces)*

------
https://chatgpt.com/codex/tasks/task_e_68af0cc5e6688328b57615fea6c47d4e