### PR TITLE
refactor token utils

### DIFF
--- a/scripts/token-utils.ts
+++ b/scripts/token-utils.ts
@@ -1,0 +1,58 @@
+import { validators } from './token-validators.ts';
+import type { TokenNode } from './token-types.js';
+
+export function validateToken(name: string, type: string | undefined, value: any) {
+  if (!type) throw new Error(`Token '${name}' is missing $type`);
+
+  const validate = validators[type];
+  if (!validate) throw new Error(`Unknown $type '${type}' for token '${name}'`);
+
+  if (value !== null && typeof value === 'object') {
+    for (const v of Object.values(value)) {
+      validate(name, v);
+    }
+  } else {
+    validate(name, value);
+  }
+}
+
+export function traverseTokens(
+  obj: TokenNode,
+  cb: (name: string, token: TokenNode) => void = () => {},
+  prefix: string[] = []
+): void {
+  for (const [key, val] of Object.entries(obj)) {
+    if (key.startsWith('$')) continue;
+    if (!/^[a-z0-9_-]+$/.test(key)) {
+      const fullName = [...prefix, key].join('.');
+      throw new Error(
+        `Invalid token key '${fullName}'. Keys may only include lowercase letters, digits, hyphen, and underscore.`
+      );
+    }
+    const name = [...prefix, key].join('.');
+    if (val && typeof val === 'object' && '$value' in val) {
+      if (val.$value === undefined) throw new Error(`Token '${name}' is missing $value`);
+      validateToken(name, val.$type, val.$value);
+      cb(name, val as TokenNode);
+    } else if (val && typeof val === 'object') {
+      if ('$type' in val && !('$value' in val)) {
+        throw new Error(`Token '${name}' is missing $value`);
+      }
+      traverseTokens(val as TokenNode, cb, [...prefix, key]);
+    }
+  }
+}
+
+export function flattenTokens(obj: TokenNode): { name: string; value: any }[] {
+  const out: { name: string; value: any }[] = [];
+  const seen = new Set<string>();
+  traverseTokens(obj, (name, token) => {
+    const nameKey = name.replace(/\./g, '-');
+    if (seen.has(nameKey)) {
+      throw new Error(`Duplicate token name '${nameKey}'`);
+    }
+    seen.add(nameKey);
+    out.push({ name, value: token.$value });
+  });
+  return out;
+}

--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -2,60 +2,12 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import Ajv from 'ajv';
-import * as csstree from 'css-tree';
 import type { TokenNode } from './token-types.js';
-import { validators } from './token-validators.js';
+import { traverseTokens } from './token-utils.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-/* eslint-disable no-unused-vars */
-type Validator = (value: any) => void;
-/* eslint-enable no-unused-vars */
-
-interface TokenNode {
-  $type?: string;
-  $value?: any;
-  [key: string]: any;
-}
-
-function validateToken(name: string, type: string | undefined, value: any) {
-  if (!type) throw new Error(`Token '${name}' is missing $type`);
-
-  const validate: Validator | undefined = validators[type];
-  if (!validate) throw new Error(`Unknown $type '${type}' for token '${name}'`);
-
-  if (value !== null && typeof value === 'object') {
-    for (const v of Object.values(value)) {
-      validate(name, v);
-    }
-  } else {
-    validate(name, value);
-  }
-}
-
-function traverse(obj: TokenNode, prefix: string[] = []): void {
-  for (const [key, val] of Object.entries(obj)) {
-    if (key.startsWith('$')) continue;
-    if (!/^[a-z0-9_-]+$/.test(key)) {
-      const fullName = [...prefix, key].join('.');
-      throw new Error(
-        `Invalid token key '${fullName}'. Keys may only include lowercase letters, digits, hyphen, and underscore.`
-      );
-    }
-    const name = [...prefix, key].join('.');
-    if (val && typeof val === 'object' && '$value' in val) {
-      if (val.$value === undefined) throw new Error(`Token '${name}' is missing $value`);
-      validateToken(name, val.$type, val.$value);
-    } else if (val && typeof val === 'object') {
-      if ('$type' in val && !('$value' in val)) {
-        throw new Error(`Token '${name}' is missing $value`);
-      }
-      traverse(val as TokenNode, [...prefix, key]);
-    }
-  }
-}
-
-async function validate() {
+ async function validate() {
   const src = path.join(root, 'tokens', 'source', 'tokens.json');
   const raw = JSON.parse(await fs.readFile(src, 'utf8')) as TokenNode;
 
@@ -70,7 +22,7 @@ async function validate() {
     throw new Error(`Token schema validation failed: ${msg}`);
   }
 
-  traverse(raw);
+  traverseTokens(raw);
 }
 
 validate()

--- a/tests/token-utils.test.js
+++ b/tests/token-utils.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+
+const { traverseTokens, flattenTokens, validateToken } = require('../scripts/token-utils.ts');
+
+test('traverseTokens visits all tokens', () => {
+  const names = [];
+  traverseTokens(
+    { color: { bg: { $type: 'color', $value: '#fff' }, text: { $type: 'color', $value: '#000' } } },
+    name => names.push(name)
+  );
+  assert.deepEqual(names.sort(), ['color.bg', 'color.text']);
+});
+
+test('validateToken rejects unknown types', () => {
+  assert.throws(() => validateToken('foo', 'unknown', '#fff'), /Unknown \$type 'unknown'/);
+});
+
+test('flattenTokens detects duplicate names', () => {
+  assert.throws(
+    () =>
+      flattenTokens({
+        'a-b': { $type: 'color', $value: '#fff' },
+        a: { b: { $type: 'color', $value: '#000' } }
+      }),
+    /Duplicate token name 'a-b'/
+  );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "lib": ["ES2022", "DOM"],
-    "types": ["node"]
+    "types": ["node"],
+    "allowImportingTsExtensions": true
   },
   "include": ["scripts/**/*", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- centralize token traversal and validation utilities
- update build and validation scripts to reuse shared helpers
- add tests for token utilities and enable TS extension imports

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af0cc5fbbc8328ac8afe00e90fb2fb