### PR TITLE
refactor: streamline token validation script

### DIFF
--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -7,47 +7,6 @@ import { traverseTokens } from './token-utils.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-/* eslint-disable no-unused-vars */
-type Validator = (value: any) => void;
-/* eslint-enable no-unused-vars */
-
-function validateToken(name: string, type: string | undefined, value: any) {
-  if (!type) throw new Error(`Token '${name}' is missing $type`);
-
-  const validate: Validator | undefined = validators[type];
-  if (!validate) throw new Error(`Unknown $type '${type}' for token '${name}'`);
-
-  if (value !== null && typeof value === 'object') {
-    for (const v of Object.values(value)) {
-      validate(name, v);
-    }
-  } else {
-    validate(name, value);
-  }
-}
-
-function traverse(obj: TokenNode, prefix: string[] = []): void {
-  for (const [key, val] of Object.entries(obj)) {
-    if (key.startsWith('$')) continue;
-    if (!/^[a-z0-9_-]+$/.test(key)) {
-      const fullName = [...prefix, key].join('.');
-      throw new Error(
-        `Invalid token key '${fullName}'. Keys may only include lowercase letters, digits, hyphen, and underscore.`
-      );
-    }
-    const name = [...prefix, key].join('.');
-    if (val && typeof val === 'object' && '$value' in val) {
-      if (val.$value === undefined) throw new Error(`Token '${name}' is missing $value`);
-      validateToken(name, val.$type, val.$value);
-    } else if (val && typeof val === 'object') {
-      if ('$type' in val && !('$value' in val)) {
-        throw new Error(`Token '${name}' is missing $value`);
-      }
-      traverse(val as TokenNode, [...prefix, key]);
-    }
-  }
-}
-
 async function validate() {
   const src = path.join(root, 'tokens', 'source', 'tokens.json');
   const raw = JSON.parse(await fs.readFile(src, 'utf8')) as TokenNode;


### PR DESCRIPTION
## Summary
- remove redundant validateToken and traverse implementations from validate-tokens script
- rely on traverseTokens utility for token validation
- restore token dist artifacts

## Testing
- `pnpm lint` (fails: token-utils.ts and build-tokens.test.js lint errors)
- `pnpm test` (fails: token-utils.test.js)
- `pnpm run tokens:validate`

------
https://chatgpt.com/codex/tasks/task_e_68b1e58ccc548328886a6544dc2a04ea