### PR TITLE
feat: export build function for token generation

### DIFF
--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -7,7 +7,7 @@ import type { TokenNode } from './token-types.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
- async function build() {
+export async function build() {
   const src = path.join(root, 'tokens', 'source', 'tokens.json');
   const dist = path.join(root, 'dist');
   await fs.mkdir(dist, { recursive: true });
@@ -105,4 +105,9 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
   ]);
 }
 
-build().catch(err => { console.error(err); process.exit(1); });
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  build().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -5,15 +5,18 @@ const path = require('path');
 const { execFile } = require('child_process');
 
 const root = path.join(__dirname, '..');
-const script = path.join(root, 'scripts', 'build-tokens.ts');
 const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
 
 function runBuild() {
   return new Promise((resolve, reject) => {
     execFile(
       'npx',
-      ['tsx', script],
-      { cwd: __dirname },
+      [
+        'tsx',
+        '-e',
+        "import('./scripts/build-tokens.ts').then(m => m.build());",
+      ],
+      { cwd: root },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim()));
         else resolve(stdout);

--- a/tests/token-utils.test.js
+++ b/tests/token-utils.test.js
@@ -1,29 +1,44 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-require('ts-node/register');
+const { execFile } = require('child_process');
+const path = require('path');
 
-const { traverseTokens, flattenTokens, validateToken } = require('../scripts/token-utils.ts');
+const root = path.join(__dirname, '..');
 
-test('traverseTokens visits all tokens', () => {
-  const names = [];
-  traverseTokens(
-    { color: { bg: { $type: 'color', $value: '#fff' }, text: { $type: 'color', $value: '#000' } } },
-    name => names.push(name)
+function runEval(code) {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'npx',
+      ['tsx', '-e', code],
+      { cwd: root },
+      (error, stdout, stderr) => {
+        if (error) reject(new Error(stderr.trim() || stdout.trim()));
+        else resolve(stdout.trim());
+      }
+    );
+  });
+}
+
+test('traverseTokens visits all tokens', async () => {
+  const result = await runEval(
+    "import { traverseTokens } from './scripts/token-utils.ts'; const names=[]; traverseTokens({ color: { bg: { $type: 'color', $value: '#fff' }, text: { $type: 'color', $value: '#000' } } }, n=>names.push(n)); console.log(JSON.stringify(names));"
   );
+  const names = JSON.parse(result);
   assert.deepEqual(names.sort(), ['color.bg', 'color.text']);
 });
 
-test('validateToken rejects unknown types', () => {
-  assert.throws(() => validateToken('foo', 'unknown', '#fff'), /Unknown \$type 'unknown'/);
+test('validateToken rejects unknown types', async () => {
+  await assert.rejects(
+    runEval("import { validateToken } from './scripts/token-utils.ts'; validateToken('foo','unknown','#fff');"),
+    /Unknown \$type 'unknown'/
+  );
 });
 
-test('flattenTokens detects duplicate names', () => {
-  assert.throws(
-    () =>
-      flattenTokens({
-        'a-b': { $type: 'color', $value: '#fff' },
-        a: { b: { $type: 'color', $value: '#000' } }
-      }),
+test('flattenTokens detects duplicate names', async () => {
+  await assert.rejects(
+    runEval(
+      "import { flattenTokens } from './scripts/token-utils.ts'; flattenTokens({ 'a-b': { $type: 'color', $value: '#fff' }, a: { b: { $type: 'color', $value: '#000' } } });"
+    ),
     /Duplicate token name 'a-b'/
   );
 });


### PR DESCRIPTION
## Summary
- export `build` from `scripts/build-tokens.ts` and run only when executed directly
- adjust tests to call exported `build` function through `tsx`
- rewrite token utils tests to evaluate utilities via `tsx`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e58ab7fc83289c53ec5731691cb0