### PR TITLE
tests: run ts scripts with node instead of npx

### DIFF
--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const { promises: fs } = require('fs');
 const path = require('path');
 const { execFile } = require('child_process');
+const tsx = require.resolve('tsx');
 
 const root = path.join(__dirname, '..');
 const script = path.join(root, 'scripts', 'build-tokens.ts');
@@ -12,12 +13,8 @@ const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
 function runBuild() {
   return new Promise((resolve, reject) => {
     execFile(
-      'npx',
-      [
-        'tsx',
-        '-e',
-        "import('./scripts/build-tokens.ts').then(m => m.build());",
-      ],
+      process.execPath,
+      ['--import', tsx, script],
       { cwd: root },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim()));
@@ -30,8 +27,8 @@ function runBuild() {
 function runValidate() {
   return new Promise((resolve, reject) => {
     execFile(
-      'npx',
-      ['tsx', validateScript],
+      process.execPath,
+      ['--import', tsx, validateScript],
       { cwd: __dirname },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim()));

--- a/tests/token-utils.test.js
+++ b/tests/token-utils.test.js
@@ -1,17 +1,15 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-require('ts-node').register({ compilerOptions: { module: 'CommonJS' } });
-require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'CommonJS' } });
-
 const { execFile } = require('child_process');
 const path = require('path');
+const tsx = require.resolve('tsx');
 const root = path.join(__dirname, '..');
 
 function runEval(code) {
   return new Promise((resolve, reject) => {
     execFile(
-      'npx',
-      ['tsx', '-e', code],
+      process.execPath,
+      ['--import', tsx, '-e', code],
       { cwd: root },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim() || stdout.trim()));


### PR DESCRIPTION
## Summary
- run token build and validate scripts via `process.execPath` with tsx loader
- remove npx usage in token utils tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b76d0fb883288864958f07dd6192