### PR TITLE
feat: validate token group structure

### DIFF
--- a/scripts/token-utils.ts
+++ b/scripts/token-utils.ts
@@ -21,6 +21,10 @@ export function traverseTokens(
   cb: (name: string, token: TokenNode) => void = () => {},
   prefix: string[] = []
 ): void {
+  if (Array.isArray(obj)) {
+    const fullName = prefix.join('.') || '(root)';
+    throw new Error(`Token group '${fullName}' must be an object, not an array`);
+  }
   for (const [key, val] of Object.entries(obj)) {
     if (key.startsWith('$')) continue;
     if (!/^[a-z0-9_-]+$/.test(key)) {

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -93,7 +93,8 @@ test('validate script uses shared schema validator', { concurrency: false }, asy
     const sanitize = (msg) =>
       msg
         .split('\n')
-        .filter(line => !line.startsWith('npm warn') && line.trim() !== '')[0];
+        .filter(line => !line.startsWith('npm warn') && line.trim() !== '')
+        .find(line => line.startsWith('Error:')) || '';
     assert.equal(sanitize(buildErr.message), sanitize(validateErr.message));
   } finally {
     await fs.writeFile(tokensPath, original);

--- a/tests/token-utils.test.js
+++ b/tests/token-utils.test.js
@@ -44,3 +44,15 @@ test('flattenTokens detects duplicate names', async () => {
     /Duplicate token name 'a-b'/
   );
 });
+
+test('traverseTokens rejects array groups', async () => {
+  await assert.rejects(
+    runEval("import { traverseTokens } from './scripts/token-utils.ts'; traverseTokens([]);"),
+    err => {
+      assert.ok(
+        err.message.includes("Token group '(root)' must be an object, not an array")
+      );
+      return true;
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- guard against arrays in `traverseTokens`
- test array input rejection
- fix schema validator comparison in build tokens test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b76e02608328a5bb196628516502