### PR TITLE
test: remove redundant ts-node registration

### DIFF
--- a/tests/token-utils.test.js
+++ b/tests/token-utils.test.js
@@ -1,6 +1,5 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-require('ts-node').register({ compilerOptions: { module: 'CommonJS' } });
 require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'CommonJS' } });
 
 const { execFile } = require('child_process');


### PR DESCRIPTION
## Summary
- remove duplicate ts-node registration in token utilities test

## Testing
- `pnpm test` *(fails: validate script uses shared schema validator)*
- `node --test tests/token-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9b76bead48328b2d2d8d5cbbb2955