### PR TITLE
feat: scaffold index exports style module

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -155,7 +155,7 @@ export async function scaffoldComponent(rawName, baseDir = 'packages/components'
 
     const componentSrc = `export const ${name} = () => {\n  // TODO: implement ${name} component\n};\n`;
     const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
-    const indexSrc = `export * from './${name}';\n`;
+    const indexSrc = `export * from './${name}';\nexport * from './style';\n`;
     const testSrc = `describe('${name}', () => {\n  it('should render correctly', () => {\n    expect(true).toBe(true);\n  });\n});\n`;
 
     const componentsIndexPath = join(componentsDir, 'index.ts');

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -191,7 +191,10 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       style,
       `export interface ExampleComponentStyleProps {\n  // TODO: define style props\n}\n\nexport const createExampleComponentStyles = (_: ExampleComponentStyleProps) => {\n  // TODO: implement Style API\n};\n`
     );
-    assert.equal(index, `export * from './ExampleComponent';\n`);
+    assert.equal(
+      index,
+      `export * from './ExampleComponent';\nexport * from './style';\n`
+    );
     assert.equal(
       testFile,
       `describe('ExampleComponent', () => {\n  it('should render correctly', () => {\n    expect(true).toBe(true);\n  });\n});\n`


### PR DESCRIPTION
## Summary
- export style module from scaffolded component index
- test that scaffolded index includes style export

## Testing
- `pnpm test` *(fails: validate script uses shared schema validator)*
- `node --test tests/scaffold-component.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9b76bd6888328b838d9c1fd33760c