### PR TITLE
chore: use js extension for token validators import

### DIFF
--- a/scripts/token-utils.ts
+++ b/scripts/token-utils.ts
@@ -1,4 +1,4 @@
-import { validators } from './token-validators.ts';
+import { validators } from './token-validators.js';
 import type { TokenNode } from './token-types.js';
 
 export function validateToken(name: string, type: string | undefined, value: any) {


### PR DESCRIPTION
## Summary
- import token validators using .js extension for Node ESM compat

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c625533c8328afbc99a715e66c09