### PR TITLE
Use node:test for component scaffold tests

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -156,7 +156,7 @@ export async function scaffoldComponent(rawName, baseDir = 'packages/components'
     const componentSrc = `export const ${name} = () => {\n  // TODO: implement ${name} component\n};\n`;
     const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
     const indexSrc = `export * from './${name}';\nexport * from './style';\n`;
-    const testSrc = `describe('${name}', () => {\n  it('should render correctly', () => {\n    expect(true).toBe(true);\n  });\n});\n`;
+    const testSrc = `import test from 'node:test';\nimport assert from 'node:assert/strict';\n\ntest('${name}', () => {\n  assert.equal(1, 1);\n});\n`;
 
     const componentsIndexPath = join(componentsDir, 'index.ts');
     let previousIndex = '';


### PR DESCRIPTION
## Summary
- scaffold components with a Node test example using `node:test` and `node:assert/strict`

## Testing
- `pnpm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c62159e883288df18a26451b6b6c