### PR TITLE
feat: expand booking widget demo

### DIFF
--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -1,40 +1,178 @@
-customElements.define("booking-widget", class extends HTMLElement {
+class BookingWidget extends HTMLElement {
+  static get observedAttributes() {
+    return ["theme", "variant", "density"];
+  }
   constructor() {
     super();
-    const r = this.attachShadow({ mode: "open" });
-    r.innerHTML = `
+    this.attachShadow({ mode: "open" });
+    this.shadowRoot.innerHTML = `
       <style>
-        @layer reset, base, components;
+        @layer reset, base, components, overrides;
+
         :host {
-          --bk-brand: var(--color-brand);
-          --bk-text: var(--color-text);
-          container-type: inline-size;
+          /* Defaults (page can override these at runtime) */
+          --bk-font: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+          --bk-bg: #f7f7fb;
+          --bk-surface: #ffffff;
+          --bk-text: #0f172a;
+          --bk-muted: #64748b;
+          --bk-brand: #4f46e5;           /* indigo */
+          --bk-brand-text: #ffffff;
+          --bk-radius: 16px;
+          --bk-gap: .75rem;
+          --bk-pad: 1rem;
+          --bk-shadow: 0 8px 30px rgba(2, 6, 23, .08);
+          --bk-border: 1px solid rgba(2, 6, 23, .08);
+
           display: block;
+          font: 400 14px/1.45 var(--bk-font);
           color: var(--bk-text);
+          /* Container queries: descendants can adapt to host width */
+          container-type: inline-size;
         }
+
+        :host([theme="dark"]) {
+          --bk-bg: #0b0d13;
+          --bk-surface: #12141b;
+          --bk-text: #e6e8ef;
+          --bk-muted: #98a2b3;
+          --bk-shadow: 0 10px 36px rgba(0,0,0,.45);
+          --bk-border: 1px solid rgba(255,255,255,.12);
+        }
+
+        :host([density="compact"]) {
+          --bk-gap: .5rem;
+          --bk-pad: .75rem;
+          --bk-radius: 12px;
+        }
+
+        @layer reset {
+          *,*::before,*::after { box-sizing: border-box; }
+          button, input, select { font: inherit; color: inherit; }
+          button { cursor: pointer; }
+        }
+
         @layer base {
           .card {
-            padding: 1rem;
-            border: 1px solid var(--bk-brand);
-            border-radius: 16px;
+            background: var(--bk-surface);
+            border-radius: var(--bk-radius);
+            padding: var(--bk-pad);
+            box-shadow: var(--bk-shadow);
+            border: var(--bk-border);
+            display: grid;
+            gap: var(--bk-gap);
           }
-          .button {
-            background: var(--bk-brand);
-            color: white;
-            border: 0;
-            padding: .7rem 1rem;
+
+          .header {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            align-items: center;
+            gap: .75rem;
+          }
+          .title { font-size: 1rem; font-weight: 700; }
+          .subtitle { color: var(--bk-muted); font-size: .875rem; }
+
+          .form { display: grid; gap: var(--bk-gap); }
+          .row { display: grid; gap: var(--bk-gap); grid-template-columns: 1fr; }
+          @container (min-width: 420px) {
+            .row { grid-template-columns: 1fr 1fr; }
+          }
+
+          .field { display: grid; gap: .35rem; }
+          .label { font-size: .75rem; color: var(--bk-muted); }
+          .input {
+            appearance: none;
+            border: 1px solid rgba(2, 6, 23, .15);
+            background: transparent;
+            color: inherit;
             border-radius: 12px;
-            cursor: pointer;
+            padding: .65rem .75rem;
           }
-          .button:focus-visible {
-            outline: 2px solid var(--bk-text);
-            outline-offset: 2px;
+          :host([theme="dark"]) .input { border-color: rgba(255,255,255,.18); }
+
+          .button {
+            display: inline-flex; align-items: center; justify-content: center; gap: .5rem;
+            padding: .7rem 1rem; border-radius: 12px; border: 0;
+            font-weight: 700;
+            background: var(--bk-brand); color: var(--bk-brand-text);
+          }
+          .button:focus-visible { outline: 2px solid rgba(0,0,0,.2); outline-offset: 2px; }
+
+          :host([variant="ghost"]) .button {
+            background: transparent;
+            color: var(--bk-brand);
+            border: 1px solid currentColor;
           }
         }
+
+        @layer components {
+          /* expose parts for host customization */
+          .card     { position: relative; }
+        }
       </style>
+
       <div class="card" part="card">
-        <button class="button" part="button" type="button" aria-label="Book reservation">Book</button>
+        <div class="header" part="header">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="17" rx="3" stroke="currentColor" opacity=".15"></rect>
+            <path d="M3 9h18" stroke="currentColor" opacity=".25"></path>
+            <circle cx="8.5" cy="13.5" r="1.25" fill="currentColor"></circle>
+            <circle cx="12" cy="13.5" r="1.25" fill="currentColor" opacity=".6"></circle>
+            <circle cx="15.5" cy="17" r="1.25" fill="currentColor"></circle>
+          </svg>
+          <div>
+            <div class="title"   part="title">Book a slot</div>
+            <div class="subtitle" part="subtitle">Pick a date, time & guests</div>
+          </div>
+        </div>
+
+        <form class="form" part="form">
+          <div class="row">
+            <label class="field" part="field">
+              <span class="label" part="label">Date</span>
+              <input class="input" part="input date" type="date" name="date" required />
+            </label>
+            <label class="field" part="field">
+              <span class="label" part="label">Time</span>
+              <select class="input" part="input select" name="time" required>
+                <option value="" disabled selected>Select…</option>
+                <option>09:00</option><option>10:00</option><option>11:00</option>
+                <option>13:00</option><option>14:00</option><option>15:00</option>
+              </select>
+            </label>
+            <label class="field" part="field">
+              <span class="label" part="label">Guests</span>
+              <input class="input" part="input number" type="number" name="guests" min="1" max="12" value="2" />
+            </label>
+            <label class="field" part="field">
+              <span class="label" part="label">Notes (optional)</span>
+              <input class="input" part="input text" type="text" name="notes" placeholder="Allergies, requests…" />
+            </label>
+          </div>
+
+          <button class="button" part="button" type="submit">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M5 12l4 4L19 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            Book
+          </button>
+        </form>
       </div>
     `;
   }
-});
+  connectedCallback() {
+    this.shadowRoot.querySelector("form")?.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const fd = new FormData(e.currentTarget);
+      const detail = Object.fromEntries(fd.entries());
+      this.dispatchEvent(new CustomEvent("book", {
+        detail,
+        bubbles: true
+      }));
+    });
+  }
+  attributeChangedCallback() {
+    // No-op: CSS reacts to [theme], [variant], [density].
+  }
+}
+customElements.define("booking-widget", BookingWidget);

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,26 +1,147 @@
 <!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>Booking Widget Demo</title>
-    <link rel="stylesheet" href="./dist/tokens.css">
-    <script type="module" src="./booking-widget.js"></script>
-    <style>
-      body { font-family: sans-serif; padding: 2rem; }
-    </style>
-  </head>
-  <body>
-    <h1>Booking Widget Demo</h1>
-    <p>Use Tab to focus the button; it includes an accessible label, a
-    <code>type="button"</code> attribute, and a focus style.</p>
-    <booking-widget id="w"></booking-widget>
-    <script>
-      const w = document.getElementById('w');
-      // runtime theming after load
-      setTimeout(() => {
-        w.style.setProperty('--bk-brand', '#ff3b3b');
-        document.documentElement.setAttribute('data-theme', 'dark');
-      }, 1000);
-    </script>
-  </body>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Booking Widget — Style API Demo</title>
+  <style>
+    /* Demo page only */
+    :root {
+      color-scheme: light dark;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100dvh;
+      display: grid;
+      place-items: center;
+      font: 14px/1.45 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      background: canvas;
+      color: canvastext;
+    }
+
+    .demo {
+      display: grid;
+      gap: 1rem;
+      align-items: start;
+    }
+
+    .controls {
+      display: grid;
+      gap: .5rem;
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+    }
+
+    .controls label {
+      display: grid;
+      gap: .25rem;
+      font-size: 12px;
+      color: gray;
+    }
+
+    .controls input[type="color"],
+    .controls select,
+    .controls button {
+      padding: .45rem .6rem;
+      border-radius: 10px;
+      border: 1px solid rgba(0, 0, 0, .15);
+      background: transparent;
+      color: inherit;
+      font: inherit;
+    }
+
+    .row {
+      display: grid;
+      gap: 1rem;
+    }
+
+    @media (min-width: 720px) {
+      .row {
+        grid-template-columns: 360px 360px;
+      }
+    }
+
+    /* Example of host-page theming via CSS vars and ::part */
+    .brand-acme booking-widget {
+      --bk-brand: #16a34a;
+      /* green */
+      --bk-radius: 14px;
+    }
+
+    .brand-acme booking-widget::part(title) {
+      letter-spacing: .2px;
+    }
+
+    .brand-acme booking-widget::part(button) {
+      border-radius: 999px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="demo">
+    <div class="controls">
+      <label>Theme
+        <select id="theme">
+          <option value="">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </label>
+      <label>Variant
+        <select id="variant">
+          <option value="solid">Solid</option>
+          <option value="ghost">Ghost</option>
+        </select>
+      </label>
+      <label>Brand color
+        <input id="brand" type="color" value="#4f46e5" />
+      </label>
+      <label>Density
+        <select id="density">
+          <option value="default">Default</option>
+          <option value="compact">Compact</option>
+        </select>
+      </label>
+    </div>
+
+    <div class="row">
+      <booking-widget id="widget"></booking-widget>
+
+      <!-- Same widget, themed by the host page with CSS vars and ::part -->
+      <div class="brand-acme">
+        <booking-widget theme="dark" variant="ghost"></booking-widget>
+      </div>
+    </div>
+
+    <pre id="log" style="margin:0;opacity:.7"></pre>
+  </div>
+
+  <script type="module">
+    import './booking-widget.js';
+    const widget = document.getElementById("widget");
+    const log = document.getElementById("log");
+    document.getElementById("theme").addEventListener("change", (e) => {
+      const v = e.target.value;
+      if (v) widget.setAttribute("theme", v);
+      else widget.removeAttribute("theme");
+    });
+    document.getElementById("variant").addEventListener("change", (e) => {
+      widget.setAttribute("variant", e.target.value);
+    });
+    document.getElementById("density").addEventListener("change", (e) => {
+      const v = e.target.value;
+      if (v === "compact") widget.setAttribute("density", "compact");
+      else widget.removeAttribute("density");
+    });
+    document.getElementById("brand").addEventListener("input", (e) => {
+      widget.style.setProperty("--bk-brand", e.target.value);
+    });
+    // Listen for bookings (what a host page would do)
+    addEventListener("book", (e) => {
+      const d = e.detail;
+      log.textContent = `Booked: ${JSON.stringify(d)}`;
+    });
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
## Summary
- Replace minimal example with full booking widget form and theming controls
- Implement feature-rich `<booking-widget>` custom element with styling API support

## Testing
- `pnpm test` *(fails: scaffoldComponent returns true and generates expected files)*

------
https://chatgpt.com/codex/tasks/task_e_68ba34450b1c83289e2ecdf1fe92c229