### PR TITLE
feat: add name field to booking widget

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,8 @@
 
 This directory demonstrates a minimal Capsule widget built with Shadow DOM.
 Its internal action uses a `<button type="button">` element to avoid
-unintended form submissions.
+unintended form submissions. The form collects a name, date, time, guest
+count and optional notes.
 
 ## Usage
 

--- a/examples/booking-widget.js
+++ b/examples/booking-widget.js
@@ -183,12 +183,16 @@ class BookingWidget extends HTMLElement {
           </svg>
           <div>
             <div class="title" part="title">Book a slot</div>
-            <div class="subtitle" part="subtitle">Pick a date, time & guests</div>
+            <div class="subtitle" part="subtitle">Enter details, pick a date, time & guests</div>
           </div>
         </div>
 
         <form class="form" part="form">
           <div class="row">
+            <label class="field" part="field">
+              <span class="label" part="label">Name</span>
+              <input class="input" part="input text" type="text" name="name" required />
+            </label>
             <label class="field" part="field">
               <span class="label" part="label">Date</span>
               <input class="input" part="input date" type="date" name="date" required />


### PR DESCRIPTION
## Summary
- expand booking widget form to collect a guest's name
- document new form fields in example README

## Testing
- `pnpm lint` *(fails: 'name' is defined but never used, ...)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba35e5b9f08328993e73868aaea0c0