### PR TITLE
feat(tokens): allow custom default theme

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -44,9 +44,16 @@ const tokens = program.command('tokens').description('Design token utilities');
 tokens
   .command('build')
   .description('Build design tokens')
-  .action(async () => {
+  .option('--default-theme <name>', 'Default theme', 'light')
+  .action(async (options) => {
     try {
-      process.exitCode = await runCommand('pnpm', ['run', 'tokens:build']);
+      process.exitCode = await runCommand('pnpm', [
+        'run',
+        'tokens:build',
+        '--',
+        '--default-theme',
+        options.defaultTheme,
+      ]);
     } catch (err) {
       console.error(err);
       process.exitCode = 1;

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -10,11 +10,11 @@ const script = path.join(root, 'scripts', 'build-tokens.ts');
 const validateScript = path.join(root, 'scripts', 'validate-tokens.ts');
 const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
 
-function runBuild() {
+function runBuild(...args) {
   return new Promise((resolve, reject) => {
     execFile(
       process.execPath,
-      ['--import', tsx, script],
+      ['--import', tsx, script, ...args],
       { cwd: root },
       (error, stdout, stderr) => {
         if (error) reject(new Error(stderr.trim()));
@@ -266,6 +266,13 @@ test('outputs themes in deterministic order', { concurrency: false }, async () =
   } finally {
     await fs.writeFile(tokensPath, original);
   }
+});
+
+test('allows setting custom default theme', { concurrency: false }, async () => {
+  await runBuild('--default-theme', 'dark');
+  const css = await fs.readFile(path.join(root, 'dist', 'tokens.css'), 'utf8');
+  assert.match(css, /:root{\n  --color-background: #000000;/);
+  assert.match(css, /\[data-theme="light"\]{\n  --color-background: #ffffff;/);
 });
 
 test('accepts negative dimension values', { concurrency: false }, async () => {

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -197,7 +197,11 @@ test('scaffoldComponent returns true and generates expected files', async () => 
     );
     assert.equal(
       testFile,
-      `describe('ExampleComponent', () => {\n  it('should render correctly', () => {\n    expect(true).toBe(true);\n  });\n});\n`
+      "import test from 'node:test';\n" +
+        "import assert from 'node:assert/strict';\n\n" +
+        "test('ExampleComponent', () => {\n" +
+        "  assert.equal(1, 1);\n" +
+        '});\n'
     );
     assert.equal(
       rootIndex,


### PR DESCRIPTION
## Summary
- allow `build-tokens` to accept a `defaultTheme` parameter and parse `--default-theme` from CLI
- expose `--default-theme` option in `capsule tokens build`
- add tests for custom default theme and align scaffold test with node's test template

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafad2f1788328aaacfb6087590657