### PR TITLE
refactor: centralize missing command handler

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -77,38 +77,43 @@ tokens
     }
   });
 
-program
-  .command('check')
-  .description('Run lint checks')
-  .action(async () => {
-    try {
-      process.exitCode = await runCommand('pnpm', ['run', 'lint']);
-    } catch (err) {
-      console.error(err);
-      process.exitCode = 1;
-    }
-  });
+  program
+    .command('check')
+    .description('Run lint checks')
+    .action(async () => {
+      try {
+        process.exitCode = await runCommand('pnpm', ['run', 'lint']);
+      } catch (err) {
+        console.error(err);
+        process.exitCode = 1;
+      }
+    });
 
-if (
-  import.meta.url === process.argv[1] ||
-  import.meta.url === pathToFileURL(process.argv[1]).href
-)
-  await program.parseAsync(process.argv);
+  if (
+    import.meta.url === process.argv[1] ||
+    import.meta.url === pathToFileURL(process.argv[1]).href
+  )
+    await program.parseAsync(process.argv);
 
-function runCommand(command, params) {
-  return new Promise((resolve, reject) => {
-    const cmd =
-      process.platform === 'win32' && command === 'pnpm'
-        ? `${command}.cmd`
-        : command;
+  function handleMissingCommand(command, resolve) {
+    console.error(`${command} not found; install ${command} or adjust PATH.`);
+    resolve(1);
+  }
+
+  function runCommand(command, params) {
+    return new Promise((resolve, reject) => {
+      const cmd =
+        process.platform === 'win32' && command === 'pnpm'
+          ? `${command}.cmd`
+          : command;
 
     let child;
     try {
       child = spawn(cmd, params, { stdio: 'inherit' });
     } catch (err) {
       if (err.code === 'ENOENT') {
-        console.error(`${command} not found; install ${command} or adjust PATH.`);
-        return resolve(1);
+        handleMissingCommand(command, resolve);
+        return;
       }
       return reject(err);
     }
@@ -131,8 +136,7 @@ function runCommand(command, params) {
     child.on('error', (error) => {
       signals.forEach((sig) => process.off(sig, forward));
       if (error.code === 'ENOENT') {
-        console.error(`${command} not found; install ${command} or adjust PATH.`);
-        resolve(1);
+        handleMissingCommand(command, resolve);
       } else {
         reject(error);
       }

--- a/tests/capsule-cli.test.js
+++ b/tests/capsule-cli.test.js
@@ -76,16 +76,20 @@ test('check surfaces pnpm failure exit code', async () => {
   }
 });
 
-test('reports error when pnpm is missing', async () => {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
-  try {
-    const { code, stderr } = await run(['tokens', 'build'], { env: { PATH: tmp } });
-    assert.equal(code, 1);
-    assert.match(stderr, /pnpm not found/);
-  } finally {
-    await rm(tmp, { recursive: true, force: true });
-  }
-});
+  test('reports error when pnpm is missing', async () => {
+    const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));
+    try {
+      const { code, stderr } = await run(['tokens', 'build'], {
+        env: { PATH: tmp },
+      });
+      assert.equal(code, 1);
+      assert.match(stderr, /pnpm not found/);
+      const lines = stderr.trim().split(/\r?\n/);
+      assert.equal(lines.length, 1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
 
 test('resolves pnpm.cmd on Windows', async () => {
   const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-'));


### PR DESCRIPTION
## Summary
- centralize missing command handling for spawned commands in capsule-cli
- ensure missing command errors are logged once
- add test asserting single error message when pnpm is missing

## Testing
- `pnpm test tests/capsule-cli.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bafad1064c8328810f35fbebe36f30