### PR TITLE
refactor(stylelint): use postcss types for require-layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,17 +14,18 @@
     "tokens:watch": "chokidar \"tokens/source/tokens.json\" -c \"pnpm tokens:build\""
   },
   "devDependencies": {
+    "@types/css-tree": "^2.3.10",
     "@typescript-eslint/parser": "^8.39.1",
+    "ajv": "^8.12.0",
+    "chokidar-cli": "^3.0.0",
+    "css-tree": "^3.1.0",
     "eslint": "^8.57.0",
+    "postcss": "8.5.6",
     "stylelint": "^15.10.0",
     "stylelint-declaration-strict-value": "^1.10.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
-    "chokidar-cli": "^3.0.0",
     "tsx": "^4.20.4",
-    "ajv": "^8.12.0",
-    "css-tree": "^3.1.0",
-    "@types/css-tree": "^2.3.10"
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      postcss:
+        specifier: 8.5.6
+        version: 8.5.6
       stylelint:
         specifier: ^15.10.0
         version: 15.11.0(typescript@5.9.2)

--- a/stylelint/require-layer.ts
+++ b/stylelint/require-layer.ts
@@ -4,10 +4,7 @@ import stylelint, {
   type Utils,
   type PostcssResult,
 } from 'stylelint';
-
-type Root = any;
-type AtRule = any;
-type Node = any;
+import type { Root, AtRule, Node } from 'postcss';
 
 type Result = PostcssResult;
 


### PR DESCRIPTION
## Summary
- use PostCSS Root, AtRule, and Node types in require-layer rule
- add postcss dev dependency for type availability

## Testing
- `pnpm run build:stylelint-plugin`
- `pnpm test` *(fails: scaffoldComponent returns true and generates expected files)*

------
https://chatgpt.com/codex/tasks/task_e_68bafad0a6408328bd3aad2f4005228c