### PR TITLE
feat(core): add preview component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Everything else stays private.
 
 ---
 
+## Preview components
+
+An early preview package `@capsule-ui/core` publishes foundational elements for experimentation:
+
+- `<caps-button>` – styled button element
+- `<caps-input>` – basic text input
+- `<caps-card>` – surface container
+- `<caps-tabs>` – tabbed interface
+- `<caps-modal>` – modal dialog
+
+Install with `pnpm add @capsule-ui/core` and try them in your project. Feedback is welcome while these components evolve.
+
+
 ## Quick start (vanilla, using the demo widget)
 Drop this into any HTML page:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,13 @@
+# @capsule-ui/core
+
+Preview package containing fundamental Capsule UI components.
+
+## Components
+
+- `<caps-button>` – styled button element.
+- `<caps-input>` – basic text input.
+- `<caps-card>` – surface container with padding and shadow.
+- `<caps-tabs>` – tabbed interface using `slot="tab"` and `slot="panel"`.
+- `<caps-modal>` – modal dialog shown when `open` attribute is present.
+
+These components are early previews for experimentation and feedback.

--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -1,0 +1,42 @@
+class CapsButton extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: inline-block; }
+        button {
+          font: inherit;
+          padding: 0.5rem 1rem;
+          border: none;
+          border-radius: 0.375rem;
+          background: var(--caps-btn-bg, #4f46e5);
+          color: var(--caps-btn-color, #fff);
+        }
+        button:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
+        button[disabled] { opacity: 0.6; cursor: not-allowed; }
+      </style>
+      <button part="button" type="button"><slot></slot></button>
+    `;
+  }
+
+  static get observedAttributes() { return ['disabled', 'type']; }
+
+  attributeChangedCallback(name, _old, value) {
+    const btn = this.shadowRoot.querySelector('button');
+    if (!btn) return;
+    if (name === 'disabled') {
+      if (value !== null) btn.setAttribute('disabled', '');
+      else btn.removeAttribute('disabled');
+    }
+    if (name === 'type') {
+      btn.setAttribute('type', value || 'button');
+    }
+  }
+}
+
+if (!customElements.get('caps-button')) {
+  customElements.define('caps-button', CapsButton);
+}
+
+export { CapsButton };

--- a/packages/core/card.js
+++ b/packages/core/card.js
@@ -1,0 +1,25 @@
+class CapsCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+        .card {
+          background: var(--caps-card-bg, #fff);
+          border: var(--caps-card-border, 1px solid #e5e7eb);
+          border-radius: var(--caps-card-radius, 0.5rem);
+          padding: var(--caps-card-padding, 1rem);
+          box-shadow: var(--caps-card-shadow, 0 1px 2px rgba(0,0,0,0.05));
+        }
+      </style>
+      <div class="card" part="card"><slot></slot></div>
+    `;
+  }
+}
+
+if (!customElements.get('caps-card')) {
+  customElements.define('caps-card', CapsCard);
+}
+
+export { CapsCard };

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,0 +1,5 @@
+export { CapsButton } from './button.js';
+export { CapsInput } from './input.js';
+export { CapsCard } from './card.js';
+export { CapsTabs } from './tabs.js';
+export { CapsModal } from './modal.js';

--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -1,0 +1,51 @@
+class CapsInput extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: inline-block; }
+        input {
+          font: inherit;
+          padding: 0.5rem 0.75rem;
+          border: 1px solid var(--caps-input-border, #d1d5db);
+          border-radius: 0.375rem;
+          background: var(--caps-input-bg, #fff);
+          color: var(--caps-input-color, #0f172a);
+        }
+        input:focus-visible { outline: 2px solid #4f46e5; outline-offset: 2px; }
+      </style>
+      <input part="input" />
+    `;
+  }
+
+  static get observedAttributes() { return ['value', 'type', 'placeholder', 'disabled']; }
+
+  attributeChangedCallback(name, _old, value) {
+    const input = this.shadowRoot.querySelector('input');
+    if (!input) return;
+    if (name === 'disabled') {
+      if (value !== null) input.setAttribute('disabled', '');
+      else input.removeAttribute('disabled');
+    } else {
+      if (value !== null) input.setAttribute(name, value);
+      else input.removeAttribute(name);
+    }
+  }
+
+  get value() {
+    const input = this.shadowRoot.querySelector('input');
+    return input?.value || '';
+  }
+
+  set value(v) {
+    const input = this.shadowRoot.querySelector('input');
+    if (input) input.value = v;
+  }
+}
+
+if (!customElements.get('caps-input')) {
+  customElements.define('caps-input', CapsInput);
+}
+
+export { CapsInput };

--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -1,0 +1,33 @@
+class CapsModal extends HTMLElement {
+  static get observedAttributes() { return ['open']; }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: none; position: fixed; inset: 0; }
+        :host([open]) { display: block; }
+        .backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.5); }
+        .modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: var(--caps-modal-bg, #fff); padding: 1rem; border-radius: 0.5rem; min-width: 300px; }
+      </style>
+      <div class="backdrop" part="backdrop"></div>
+      <div class="modal" part="modal"><slot></slot></div>
+    `;
+  }
+
+  connectedCallback() {
+    const backdrop = this.shadowRoot.querySelector('.backdrop');
+    backdrop?.addEventListener('click', () => this.removeAttribute('open'));
+  }
+
+  attributeChangedCallback() {
+    // styles handle visibility
+  }
+}
+
+if (!customElements.get('caps-modal')) {
+  customElements.define('caps-modal', CapsModal);
+}
+
+export { CapsModal };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@capsule-ui/core",
+  "version": "0.0.1-preview",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js"
+    }
+  }
+}

--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -1,0 +1,62 @@
+class CapsTabs extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+        .tablist { display: flex; gap: 0.25rem; }
+        .tablist ::slotted(button) {
+          background: var(--caps-tab-bg, transparent);
+          border: none;
+          padding: 0.5rem 0.75rem;
+          border-radius: 0.375rem 0.375rem 0 0;
+          cursor: pointer;
+        }
+        .tablist ::slotted(button[aria-selected='true']) {
+          background: var(--caps-tab-active-bg, #fff);
+          font-weight: 600;
+        }
+        .panels { border: 1px solid var(--caps-tab-border, #e5e7eb); border-radius: 0 0 0.375rem 0.375rem; padding: 1rem; }
+        .panels ::slotted(*) { display: none; }
+        .panels ::slotted([data-active]) { display: block; }
+      </style>
+      <div class="tabs">
+        <div class="tablist" part="tablist"><slot name="tab"></slot></div>
+        <div class="panels" part="panels"><slot name="panel"></slot></div>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    const tabSlot = this.shadowRoot.querySelector('slot[name="tab"]');
+    const panelSlot = this.shadowRoot.querySelector('slot[name="panel"]');
+    const assign = () => {
+      const tabs = tabSlot.assignedElements();
+      const panels = panelSlot.assignedElements();
+      tabs.forEach((tab, i) => {
+        tab.setAttribute('role', 'tab');
+        tab.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+        tab.addEventListener('click', () => {
+          tabs.forEach(t => t.setAttribute('aria-selected', 'false'));
+          panels.forEach(p => p.removeAttribute('data-active'));
+          tab.setAttribute('aria-selected', 'true');
+          panels[i]?.setAttribute('data-active', '');
+        });
+      });
+      panels.forEach((p, i) => {
+        p.setAttribute('role', 'tabpanel');
+        if (i === 0) p.setAttribute('data-active', '');
+      });
+    };
+    tabSlot.addEventListener('slotchange', assign);
+    panelSlot.addEventListener('slotchange', assign);
+    assign();
+  }
+}
+
+if (!customElements.get('caps-tabs')) {
+  customElements.define('caps-tabs', CapsTabs);
+}
+
+export { CapsTabs };


### PR DESCRIPTION
## Summary
- add `@capsule-ui/core` preview package exporting button, input, card, tabs and modal custom elements
- document the new components in the root README

## Testing
- `pnpm test`
- `pnpm lint` *(fails: no-unused-vars and no-regex-spaces in existing scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68bb33a5973c83288a9c4ed953a3114f