### PR TITLE
Add SSR framework examples

### DIFF
--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -1,0 +1,15 @@
+# SSR Framework Examples
+
+This directory contains reference integrations for server-side rendering with React, Vue and Svelte.
+Each example renders a simple message on the server and hydrates on the client.
+
+## Running an Example
+
+Change into one of the framework folders and install dependencies:
+
+```bash
+pnpm install
+pnpm run dev
+```
+
+Then visit `http://localhost:3000` in a browser to see the hydrated output.

--- a/examples/ssr/react/App.js
+++ b/examples/ssr/react/App.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function App({ message }) {
+  return React.createElement('h1', null, message);
+}

--- a/examples/ssr/react/client.js
+++ b/examples/ssr/react/client.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { App } from './App.js';
+
+hydrateRoot(
+  document.getElementById('root'),
+  React.createElement(App, { message: 'Hello from React SSR' })
+);

--- a/examples/ssr/react/package.json
+++ b/examples/ssr/react/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "capsule-ui-react-ssr-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/examples/ssr/react/server.js
+++ b/examples/ssr/react/server.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { App } from './App.js';
+
+const app = express();
+
+app.use('/client.js', express.static('client.js'));
+
+app.get('/', (req, res) => {
+  const appHtml = renderToString(
+    React.createElement(App, { message: 'Hello from React SSR' })
+  );
+
+  res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>React SSR Example</title>
+</head>
+<body>
+  <div id="root">${appHtml}</div>
+  <script type="module" src="/client.js"></script>
+</body>
+</html>`);
+});
+
+app.listen(3000, () => {
+  console.log('React SSR server running on http://localhost:3000');
+});

--- a/examples/ssr/svelte/App.svelte
+++ b/examples/ssr/svelte/App.svelte
@@ -1,0 +1,5 @@
+<script>
+  export let message;
+</script>
+
+<h1>{message}</h1>

--- a/examples/ssr/svelte/client.js
+++ b/examples/ssr/svelte/client.js
@@ -1,0 +1,9 @@
+import App from './App.svelte';
+
+const app = new App({
+  target: document.getElementById('svelte'),
+  hydrate: true,
+  props: { message: 'Hello from Svelte SSR' }
+});
+
+export default app;

--- a/examples/ssr/svelte/package.json
+++ b/examples/ssr/svelte/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "capsule-ui-svelte-ssr-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "svelte": "^4.2.0"
+  }
+}

--- a/examples/ssr/svelte/server.js
+++ b/examples/ssr/svelte/server.js
@@ -1,0 +1,27 @@
+import 'svelte/register';
+import express from 'express';
+import App from './App.svelte';
+
+const app = express();
+
+app.use('/client.js', express.static('client.js'));
+
+app.get('/', (req, res) => {
+  const { html, head } = App.render({ message: 'Hello from Svelte SSR' });
+  res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Svelte SSR Example</title>
+  ${head}
+</head>
+<body>
+  <div id="svelte">${html}</div>
+  <script type="module" src="/client.js"></script>
+</body>
+</html>`);
+});
+
+app.listen(3000, () => {
+  console.log('Svelte SSR server running on http://localhost:3000');
+});

--- a/examples/ssr/vue/App.js
+++ b/examples/ssr/vue/App.js
@@ -1,0 +1,8 @@
+import { h } from 'vue';
+
+export default {
+  props: ['message'],
+  render() {
+    return h('h1', this.message);
+  }
+};

--- a/examples/ssr/vue/client.js
+++ b/examples/ssr/vue/client.js
@@ -1,0 +1,5 @@
+import { createSSRApp } from 'vue';
+import App from './App.js';
+
+const app = createSSRApp(App, { message: 'Hello from Vue SSR' });
+app.mount('#app');

--- a/examples/ssr/vue/package.json
+++ b/examples/ssr/vue/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "capsule-ui-vue-ssr-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "@vue/server-renderer": "^3.4.21",
+    "express": "^4.18.2",
+    "vue": "^3.4.21"
+  }
+}

--- a/examples/ssr/vue/server.js
+++ b/examples/ssr/vue/server.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { createSSRApp } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import App from './App.js';
+
+const app = express();
+
+app.use('/client.js', express.static('client.js'));
+
+app.get('/', async (req, res) => {
+  const vueApp = createSSRApp(App, { message: 'Hello from Vue SSR' });
+  const appHtml = await renderToString(vueApp);
+
+  res.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Vue SSR Example</title>
+</head>
+<body>
+  <div id="app">${appHtml}</div>
+  <script type="module" src="/client.js"></script>
+</body>
+</html>`);
+});
+
+app.listen(3000, () => {
+  console.log('Vue SSR server running on http://localhost:3000');
+});


### PR DESCRIPTION
## Summary
- add React server-rendered example demonstrating hydration
- add Vue SSR example with createSSRApp hydration
- add Svelte SSR example rendering component and hydrating on client

## Testing
- `pnpm lint` (fails: 'k' is assigned a value but never used, etc.)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb33bd94508328af13437b5aea8039