### PR TITLE
Prevent duplicate tab click handlers

### DIFF
--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -31,18 +31,25 @@ class CapsTabs extends HTMLElement {
   connectedCallback() {
     const tabSlot = this.shadowRoot.querySelector('slot[name="tab"]');
     const panelSlot = this.shadowRoot.querySelector('slot[name="panel"]');
+    const handlers = new WeakMap();
     const assign = () => {
       const tabs = tabSlot.assignedElements();
       const panels = panelSlot.assignedElements();
       tabs.forEach((tab, i) => {
         tab.setAttribute('role', 'tab');
         tab.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
-        tab.addEventListener('click', () => {
+        const existingHandler = handlers.get(tab);
+        if (existingHandler) {
+          tab.removeEventListener('click', existingHandler);
+        }
+        const clickHandler = () => {
           tabs.forEach(t => t.setAttribute('aria-selected', 'false'));
           panels.forEach(p => p.removeAttribute('data-active'));
           tab.setAttribute('aria-selected', 'true');
           panels[i]?.setAttribute('data-active', '');
-        });
+        };
+        tab.addEventListener('click', clickHandler);
+        handlers.set(tab, clickHandler);
       });
       panels.forEach((p, i) => {
         p.setAttribute('role', 'tabpanel');


### PR DESCRIPTION
## Summary
- remove existing tab click handlers before adding new ones to avoid leaks and double firing

## Testing
- `pnpm lint` *(fails: Cannot find module 'postcss')*
- `pnpm test` *(fails: Cannot find module 'postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68bb3715bcd88328b385b23570dc0d32