### PR TITLE
feat: add disabled accessors

### DIFF
--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -26,12 +26,19 @@ class CapsButton extends HTMLElement {
     const btn = this.shadowRoot.querySelector('button');
     if (!btn) return;
     if (name === 'disabled') {
-      if (value !== null) btn.setAttribute('disabled', '');
-      else btn.removeAttribute('disabled');
+      btn.toggleAttribute('disabled', value !== null);
     }
     if (name === 'type') {
       btn.setAttribute('type', value || 'button');
     }
+  }
+
+  get disabled() {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val) {
+    this.toggleAttribute('disabled', Boolean(val));
   }
 }
 

--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -25,12 +25,19 @@ class CapsInput extends HTMLElement {
     const input = this.shadowRoot.querySelector('input');
     if (!input) return;
     if (name === 'disabled') {
-      if (value !== null) input.setAttribute('disabled', '');
-      else input.removeAttribute('disabled');
+      input.toggleAttribute('disabled', value !== null);
     } else {
       if (value !== null) input.setAttribute(name, value);
       else input.removeAttribute(name);
     }
+  }
+
+  get disabled() {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(val) {
+    this.toggleAttribute('disabled', Boolean(val));
   }
 
   get value() {


### PR DESCRIPTION
## Summary
- allow toggling `disabled` attribute via property on `caps-button` and `caps-input`
- keep internal button/input synced with host `disabled` attribute

## Testing
- `pnpm test` *(fails: Accessibility check failed Could not find expected browser (chrome) locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb37176a9883289b4f2547973e7f21