### PR TITLE
fix(input): sync value property with attribute

### DIFF
--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -27,6 +27,14 @@ class CapsInput extends HTMLElement {
     if (name === 'disabled') {
       if (value !== null) input.setAttribute('disabled', '');
       else input.removeAttribute('disabled');
+    } else if (name === 'value') {
+      if (value !== null) {
+        input.setAttribute('value', value);
+        input.value = value;
+      } else {
+        input.removeAttribute('value');
+        input.value = '';
+      }
     } else {
       if (value !== null) input.setAttribute(name, value);
       else input.removeAttribute(name);


### PR DESCRIPTION
## Summary
- ensure CapsInput keeps the input element's value property aligned with the `value` attribute, resetting the property when the attribute is removed

## Testing
- `pnpm test` *(fails: error while loading shared libraries: libxkbcommon.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3716e6a48328b8d4bddcae43f567