### PR TITLE
Add lint configuration packages

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,16 +1,13 @@
 module.exports = {
-  plugins: [
-    'stylelint-declaration-strict-value',
-    './stylelint/require-layer.js'
-  ],
+  extends: [require.resolve('./packages/stylelint-config-capsule')],
+  plugins: ['stylelint-declaration-strict-value'],
   rules: {
     'selector-max-specificity': '0,1,0',
     'scale-unlimited/declaration-strict-value': [
       ['/color/', 'fill', 'stroke'],
       {
-        ignoreValues: ['transparent', 'inherit', 'currentColor']
-      }
+        ignoreValues: ['transparent', 'inherit', 'currentColor'],
+      },
     ],
-    'capsule-ui/require-layer': { name: 'components' }
-  }
+  },
 };

--- a/docs/lint-configs.md
+++ b/docs/lint-configs.md
@@ -1,0 +1,75 @@
+# Lint configuration packages
+
+Capsule UI provides shareable configurations for Stylelint and ESLint so projects can enforce consistent layering rules across static stylesheets and runtime styling.
+
+## Packages
+
+- `stylelint-config-capsule`
+- `eslint-config-capsule`
+
+## Extending the config
+
+Both packages enable the `capsule-ui/require-layer` rule. The rule expects a `@layer components` declaration by default.
+
+### Different layer stacks
+
+Override the allowed layers in your project:
+
+```jsonc
+// .stylelintrc.json
+{
+  "extends": ["stylelint-config-capsule"],
+  "rules": {
+    "capsule-ui/require-layer": { "names": ["utilities", "components"] }
+  }
+}
+```
+
+```js
+// eslint.config.js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': ['error', { layers: ['utilities', 'components'] }],
+  },
+};
+```
+
+### Allowing runtime styling libraries
+
+The ESLint rule checks `css` template tags or function calls. You can allow additional APIs:
+
+```js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': ['error', { libraries: ['css', 'styled'] }],
+  },
+};
+```
+
+## Examples
+
+### Web Components (Lit)
+
+```js
+import { css } from 'lit';
+
+export const cardStyles = css`
+  @layer components {
+    :host { display: block; }
+  }
+`;
+```
+
+### Framework components (React)
+
+```js
+import { css } from '@emotion/css';
+
+const card = css`
+  @layer components {
+    padding: 1rem;
+  }
+`;
+```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build:stylelint-plugin": "tsc stylelint/require-layer.ts --esModuleInterop --module commonjs --target ES2022 --skipLibCheck",
+    "build:stylelint-plugin": "tsc packages/stylelint-config-capsule/require-layer.ts --esModuleInterop --module commonjs --target ES2022 --skipLibCheck",
     "lint:css": "pnpm run build:stylelint-plugin && stylelint \"**/*.{css,scss}\"",
     "lint:js": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint": "pnpm run lint:css && pnpm run lint:js",

--- a/packages/eslint-config-capsule/README.md
+++ b/packages/eslint-config-capsule/README.md
@@ -1,0 +1,69 @@
+# eslint-config-capsule
+
+Shared ESLint configuration for Capsule UI projects. It ships with a `capsule-ui/require-layer` rule that ensures runtime CSS strings declare an allowed `@layer`.
+
+## Usage
+
+Install ESLint and this config package:
+
+```sh
+pnpm add -D eslint eslint-config-capsule
+```
+
+Create an ESLint config, for example `.eslintrc.cjs`:
+
+```js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+};
+```
+
+### Custom runtime styling libraries
+
+The rule checks `css` tagged templates by default. Projects can allow additional APIs:
+
+```js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': ['error', { libraries: ['css', 'styled'] }],
+  },
+};
+```
+
+### Custom layer stacks
+
+```js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': ['error', { layers: ['utilities', 'components'] }],
+  },
+};
+```
+
+### Examples
+
+**Web Components (Lit)**
+
+```js
+import { css } from 'lit';
+
+export const buttonStyles = css`
+  @layer components {
+    :host { display: inline-block; }
+  }
+`;
+```
+
+**Framework components (React)**
+
+```js
+import { css } from '@emotion/css';
+
+const button = css`
+  @layer components {
+    color: red;
+  }
+`;
+```

--- a/packages/eslint-config-capsule/index.js
+++ b/packages/eslint-config-capsule/index.js
@@ -1,0 +1,19 @@
+const requireLayer = require('./require-layer');
+
+module.exports = {
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+  plugins: {
+    'capsule-ui': {
+      rules: {
+        'require-layer': requireLayer,
+      },
+    },
+  },
+  rules: {
+    'capsule-ui/require-layer': 'error',
+  },
+};

--- a/packages/eslint-config-capsule/package.json
+++ b/packages/eslint-config-capsule/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "eslint-config-capsule",
+  "version": "0.0.1",
+  "main": "index.js",
+  "peerDependencies": {
+    "eslint": "^8.57.0"
+  },
+  "files": ["index.js", "require-layer.js"],
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.5.2"
+}

--- a/packages/eslint-config-capsule/require-layer.js
+++ b/packages/eslint-config-capsule/require-layer.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview ESLint rule that requires CSS tagged templates or strings to include an allowed @layer declaration.
+ */
+
+const DEFAULT_LAYER = 'components';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'require an @layer declaration in runtime CSS strings',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          layer: { type: ['string', 'array'] },
+          layers: { type: ['string', 'array'] },
+          libraries: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    let expected = options.layers || options.layer || DEFAULT_LAYER;
+    if (!Array.isArray(expected)) {
+      expected = [expected];
+    }
+    const libraries = options.libraries || ['css'];
+
+    function containsLayer(text) {
+      return expected.some((name) => text.includes(`@layer ${name}`));
+    }
+
+    function report(node) {
+      context.report({
+        node,
+        message: `Expected '@layer ${expected[0]}' declaration.`,
+      });
+    }
+
+    function checkText(node, text) {
+      if (!containsLayer(text)) {
+        report(node);
+      }
+    }
+
+    return {
+      TaggedTemplateExpression(node) {
+        if (node.tag.type === 'Identifier' && libraries.includes(node.tag.name)) {
+          const text = node.quasi.quasis.map((q) => q.value.raw).join('');
+          checkText(node, text);
+        }
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && libraries.includes(node.callee.name)) {
+          const arg = node.arguments[0];
+          if (!arg) return;
+          if (arg.type === 'TemplateLiteral') {
+            const text = arg.quasis.map((q) => q.value.raw).join('');
+            checkText(arg, text);
+          } else if (arg.type === 'Literal' && typeof arg.value === 'string') {
+            checkText(arg, arg.value);
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/stylelint-config-capsule/README.md
+++ b/packages/stylelint-config-capsule/README.md
@@ -1,0 +1,50 @@
+# stylelint-config-capsule
+
+Shared Stylelint configuration for Capsule UI projects. It enables the `capsule-ui/require-layer` rule to ensure every stylesheet declares an allowed `@layer` at the root.
+
+## Usage
+
+Install Stylelint and this config package:
+
+```sh
+pnpm add -D stylelint stylelint-config-capsule
+```
+
+Create a `.stylelintrc.json`:
+
+```json
+{
+  "extends": ["stylelint-config-capsule"]
+}
+```
+
+By default the rule requires a `@layer components` declaration.
+
+### Custom layer stacks
+
+Projects can override the allowed layers by configuring the rule:
+
+```json
+{
+  "extends": ["stylelint-config-capsule"],
+  "rules": {
+    "capsule-ui/require-layer": { "names": ["utilities", "components"] }
+  }
+}
+```
+
+### Examples
+
+**Web Components**
+
+```css
+@layer components;
+:host { display: block; }
+```
+
+**Framework components**
+
+```css
+@layer components;
+.button { color: red; }
+```

--- a/packages/stylelint-config-capsule/index.js
+++ b/packages/stylelint-config-capsule/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [require.resolve('./require-layer.js')],
+  rules: {
+    'capsule-ui/require-layer': {},
+  },
+};

--- a/packages/stylelint-config-capsule/package.json
+++ b/packages/stylelint-config-capsule/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stylelint-config-capsule",
+  "version": "0.0.1",
+  "main": "index.js",
+  "peerDependencies": {
+    "stylelint": "^15.10.0"
+  },
+  "files": ["index.js", "require-layer.js", "require-layer.ts"],
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@10.5.2"
+}

--- a/packages/stylelint-config-capsule/require-layer.js
+++ b/packages/stylelint-config-capsule/require-layer.js
@@ -1,0 +1,89 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.messages = exports.ruleName = void 0;
+const stylelint_1 = __importDefault(require("stylelint"));
+exports.ruleName = 'capsule-ui/require-layer';
+const utils = stylelint_1.default.utils;
+exports.messages = utils.ruleMessages(exports.ruleName, {
+    expected: (name) => `Expected '@layer ${name}' declaration.`,
+});
+function getLineEnding(root) {
+    const css = root.source?.input.css;
+    return typeof utils.getLineEnding === 'function'
+        ? utils.getLineEnding(css)
+        : css && css.includes('\r\n')
+            ? '\r\n'
+            : '\n';
+}
+function isString(value) {
+    return typeof value === 'string';
+}
+function isStringArray(value) {
+    return Array.isArray(value) && value.every(isString);
+}
+const rule = (options = {}, _secondaryOption, context) => {
+    return (root, result) => {
+        const validOptions = utils.validateOptions(result, exports.ruleName, {
+            actual: options,
+            possible: {
+                name: [isString, isStringArray],
+                names: [isString, isStringArray],
+            },
+            optional: true,
+        });
+        if (!validOptions) {
+            return;
+        }
+        let expected = options.names || options.name || 'components';
+        if (!Array.isArray(expected)) {
+            expected = [expected];
+        }
+        const newline = getLineEnding(root);
+        let hasLayer = false;
+        root.walkAtRules('layer', (rule) => {
+            if (rule.parent !== root) {
+                return;
+            }
+            const layers = rule.params.split(',').map((l) => l.trim()).filter(Boolean);
+            if (expected.some((name) => layers.includes(name))) {
+                hasLayer = true;
+            }
+        });
+        if (!hasLayer) {
+            const first = expected[0];
+            if (context?.fix) {
+                let insertAfter = null;
+                const skip = new Set(['charset', 'import', 'namespace']);
+                for (const node of root.nodes ?? []) {
+                    if (node.type === 'comment' ||
+                        (node.type === 'atrule' && skip.has(node.name))) {
+                        insertAfter = node;
+                        continue;
+                    }
+                    break;
+                }
+                if (insertAfter) {
+                    insertAfter.after(`${newline}@layer ${first};${newline}`);
+                }
+                else {
+                    root.prepend(`@layer ${first};${newline}`);
+                    if (root.nodes[1]) {
+                        root.nodes[1].raws.before = root.nodes[1].raws.before || newline;
+                    }
+                }
+            }
+            else {
+                utils.report({
+                    ruleName: exports.ruleName,
+                    result,
+                    node: root,
+                    message: exports.messages.expected(first),
+                });
+            }
+        }
+    };
+};
+exports.default = stylelint_1.default.createPlugin(exports.ruleName, rule);

--- a/packages/stylelint-config-capsule/require-layer.ts
+++ b/packages/stylelint-config-capsule/require-layer.ts
@@ -14,7 +14,7 @@ export interface RequireLayerOptions {
 }
 
 export const ruleName = 'capsule-ui/require-layer';
-const utils: Utils & { getLineEnding?: (input: string) => string } = stylelint.utils;
+const utils: Utils & { getLineEnding?: (_input: string) => string } = stylelint.utils;
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: (name: string) => `Expected '@layer ${name}' declaration.`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,20 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
 
+  packages/core: {}
+
+  packages/eslint-config-capsule:
+    dependencies:
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+
+  packages/stylelint-config-capsule:
+    dependencies:
+      stylelint:
+        specifier: ^15.10.0
+        version: 15.11.0(typescript@5.9.2)
+
 packages:
 
   '@babel/code-frame@7.27.1':

--- a/tests/eslint-require-layer.test.js
+++ b/tests/eslint-require-layer.test.js
@@ -1,0 +1,17 @@
+const test = require('node:test');
+const { RuleTester } = require('eslint');
+const rule = require('../packages/eslint-config-capsule/require-layer');
+
+const tester = new RuleTester({ parserOptions: { ecmaVersion: 2022 } });
+
+test('reports missing layer in css tagged template', () => {
+  tester.run('capsule-ui/require-layer', rule, {
+    valid: [{ code: "css`@layer components { color: red; }`" }],
+    invalid: [
+      {
+        code: "css`color: red;`",
+        errors: [{ message: "Expected '@layer components' declaration." }],
+      },
+    ],
+  });
+});

--- a/tests/require-layer.test.js
+++ b/tests/require-layer.test.js
@@ -3,7 +3,13 @@ const assert = require('node:assert/strict');
 const stylelint = require('stylelint');
 const path = require('path');
 
-const pluginPath = path.join(__dirname, '..', 'stylelint', 'require-layer.js');
+const pluginPath = path.join(
+  __dirname,
+  '..',
+  'packages',
+  'stylelint-config-capsule',
+  'require-layer.js',
+);
 
 function lint(code, { fix = false, config = {} } = {}) {
   return stylelint.lint({


### PR DESCRIPTION
## Summary
- add shareable Stylelint config with `capsule-ui/require-layer`
- add ESLint config and runtime `require-layer` rule
- document extending lint configs and layer or library overrides

## Testing
- `pnpm run lint` *(fails: scripts/build-tokens.ts no-unused-vars)*
- `pnpm test` *(fails: Could not find expected browser chrome locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e08e5188328bff401332bf08877