### PR TITLE
Add React, Vue, and Svelte adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ An early preview package `@capsule-ui/core` publishes foundational elements for 
 
 Install with `pnpm add @capsule-ui/core` and try them in your project. Feedback is welcome while these components evolve.
 
+### Framework adapters
+
+Prefer to stay in a framework? Tiny adapters wrap the Web Components so
+they behave like native React, Vue, or Svelte components:
+
+- `@capsule-ui/react`
+- `@capsule-ui/vue`
+- `@capsule-ui/svelte`
+
+Each forwards attributes and events and keeps the same Style API for
+`::part`, CSS variables, and attributes. See
+[framework adapter docs](docs/framework-adapters.md) for usage examples.
+
 
 ## Quick start (vanilla, using the demo widget)
 Drop this into any HTML page:

--- a/docs/framework-adapters.md
+++ b/docs/framework-adapters.md
@@ -1,0 +1,86 @@
+# Framework adapters
+
+Capsule ships tiny wrappers so its Web Components fit naturally into
+popular frameworks. Each adapter forwards attributes and events and
+exposes the same Style API – CSS variables, `::part`, and attributes.
+
+## React
+
+```bash
+pnpm add @capsule-ui/react
+```
+
+```jsx
+import { CapsButton } from '@capsule-ui/react';
+
+export function Demo() {
+  return (
+    <CapsButton
+      className="caps-btn"
+      style={{ '--caps-btn-bg': '#ff3b3b' }}
+      theme="dark"
+    >
+      Save
+    </CapsButton>
+  );
+}
+```
+
+```css
+.caps-btn::part(button) { text-transform: uppercase; }
+```
+
+## Vue
+
+```bash
+pnpm add @capsule-ui/vue
+```
+
+```vue
+<script setup>
+import { CapsButton } from '@capsule-ui/vue';
+</script>
+
+<template>
+  <CapsButton
+    class="caps-btn"
+    style="--caps-btn-bg:#ff3b3b"
+    theme="dark"
+  >
+    Save
+  </CapsButton>
+</template>
+
+<style>
+.caps-btn::part(button) { text-transform: uppercase; }
+</style>
+```
+
+## Svelte
+
+```bash
+pnpm add @capsule-ui/svelte
+```
+
+```svelte
+<script>
+  import { CapsButton } from '@capsule-ui/svelte';
+</script>
+
+<CapsButton
+  class="caps-btn"
+  style="--caps-btn-bg:#ff3b3b"
+  theme="dark"
+>
+  Save
+</CapsButton>
+
+<style>
+  .caps-btn::part(button) { text-transform: uppercase; }
+</style>
+```
+
+CSS variables can be set via the `style` attribute or on ancestor
+elements. Attributes like `theme` or `variant` map to component
+variants. Parts targeted with `::part(...)` remain the sanctioned way to
+customize internals.

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,0 +1,13 @@
+import { createElement, forwardRef } from 'react';
+import '@capsule-ui/core';
+
+const createComponent = (tag) =>
+  forwardRef(({ children, ...rest }, ref) =>
+    createElement(tag, { ...rest, ref }, children)
+  );
+
+export const CapsButton = createComponent('caps-button');
+export const CapsInput = createComponent('caps-input');
+export const CapsCard = createComponent('caps-card');
+export const CapsTabs = createComponent('caps-tabs');
+export const CapsModal = createComponent('caps-modal');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@capsule-ui/react",
+  "version": "0.0.1-preview",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": { "import": "./index.js" }
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "dependencies": {
+    "@capsule-ui/core": "workspace:*"
+  }
+}

--- a/packages/svelte/Button.svelte
+++ b/packages/svelte/Button.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-button {...$$restProps}>
+  <slot />
+</caps-button>

--- a/packages/svelte/Card.svelte
+++ b/packages/svelte/Card.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-card {...$$restProps}>
+  <slot />
+</caps-card>

--- a/packages/svelte/Input.svelte
+++ b/packages/svelte/Input.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-input {...$$restProps}>
+  <slot />
+</caps-input>

--- a/packages/svelte/Modal.svelte
+++ b/packages/svelte/Modal.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-modal {...$$restProps}>
+  <slot />
+</caps-modal>

--- a/packages/svelte/Tabs.svelte
+++ b/packages/svelte/Tabs.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-tabs {...$$restProps}>
+  <slot />
+</caps-tabs>

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -1,0 +1,5 @@
+export { default as CapsButton } from './Button.svelte';
+export { default as CapsInput } from './Input.svelte';
+export { default as CapsCard } from './Card.svelte';
+export { default as CapsTabs } from './Tabs.svelte';
+export { default as CapsModal } from './Modal.svelte';

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@capsule-ui/svelte",
+  "version": "0.0.1-preview",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": { "import": "./index.js" }
+  },
+  "peerDependencies": {
+    "svelte": "^4.0.0"
+  },
+  "dependencies": {
+    "@capsule-ui/core": "workspace:*"
+  }
+}

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -1,0 +1,16 @@
+import '@capsule-ui/core';
+import { defineComponent, h } from 'vue';
+
+const createComponent = (tag, name) =>
+  defineComponent({
+    name,
+    setup(props, { slots, attrs }) {
+      return () => h(tag, { ...attrs, ...props }, slots.default ? slots.default() : undefined);
+    }
+  });
+
+export const CapsButton = createComponent('caps-button', 'CapsButton');
+export const CapsInput = createComponent('caps-input', 'CapsInput');
+export const CapsCard = createComponent('caps-card', 'CapsCard');
+export const CapsTabs = createComponent('caps-tabs', 'CapsTabs');
+export const CapsModal = createComponent('caps-modal', 'CapsModal');

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@capsule-ui/vue",
+  "version": "0.0.1-preview",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": { "import": "./index.js" }
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "dependencies": {
+    "@capsule-ui/core": "workspace:*"
+  }
+}

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -100,7 +100,7 @@ if (fileURLToPath(import.meta.url) === process.argv[1]) {
   let defaultTheme = 'light';
   const flag = process.argv.find(arg => arg.startsWith('--default-theme'));
   if (flag) {
-    const [k, v] = flag.split('=');
+    const [, v] = flag.split('=');
     if (v) defaultTheme = v;
     else {
       const idx = process.argv.indexOf(flag);

--- a/scripts/token-utils.ts
+++ b/scripts/token-utils.ts
@@ -16,9 +16,13 @@ export function validateToken(name: string, type: string | undefined, value: any
   }
 }
 
+/* eslint-disable no-unused-vars */
+type TokenCallback = (name: string, token: TokenNode) => void;
+/* eslint-enable no-unused-vars */
+
 export function traverseTokens(
   obj: TokenNode,
-  cb: (name: string, token: TokenNode) => void = () => {},
+  cb: TokenCallback = () => {},
   prefix: string[] = []
 ): void {
   if (Array.isArray(obj)) {

--- a/stylelint/require-layer.ts
+++ b/stylelint/require-layer.ts
@@ -14,7 +14,10 @@ export interface RequireLayerOptions {
 }
 
 export const ruleName = 'capsule-ui/require-layer';
-const utils: Utils & { getLineEnding?: (input: string) => string } = stylelint.utils;
+/* eslint-disable no-unused-vars */
+type LineEndingFn = (input: string) => string;
+/* eslint-enable no-unused-vars */
+const utils: Utils & { getLineEnding?: LineEndingFn } = stylelint.utils;
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: (name: string) => `Expected '@layer ${name}' declaration.`,

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -257,7 +257,7 @@ test('outputs themes in deterministic order', { concurrency: false }, async () =
       m => m[1]
     );
     assert.deepEqual(themeOrder, ['beta', 'gamma']);
-    assert.match(css, /:root{\n  --color-background: #aaa;\n}/);
+    assert.match(css, /:root{\n\s{2}--color-background: #aaa;\n}/);
     const json = await fs.readFile(path.join(root, 'dist', 'tokens.json'), 'utf8');
     const alpha = json.indexOf('"alpha"');
     const beta = json.indexOf('"beta"');
@@ -271,8 +271,8 @@ test('outputs themes in deterministic order', { concurrency: false }, async () =
 test('allows setting custom default theme', { concurrency: false }, async () => {
   await runBuild('--default-theme', 'dark');
   const css = await fs.readFile(path.join(root, 'dist', 'tokens.css'), 'utf8');
-  assert.match(css, /:root{\n  --color-background: #000000;/);
-  assert.match(css, /\[data-theme="light"\]{\n  --color-background: #ffffff;/);
+  assert.match(css, /:root{\n\s{2}--color-background: #000000;/);
+  assert.match(css, /\[data-theme="light"\]{\n\s{2}--color-background: #ffffff;/);
 });
 
 test('accepts negative dimension values', { concurrency: false }, async () => {


### PR DESCRIPTION
## Summary
- add lightweight framework adapters for React, Vue, and Svelte
- document how to style Capsule components in those frameworks
- fix lint complaints in token utilities and stylelint rule

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Accessibility check failed, missing Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e0f74988328b3abf7942b4fbe8b