### PR TITLE
feat: add shareable lint configs

### DIFF
--- a/docs/config-packages.md
+++ b/docs/config-packages.md
@@ -1,0 +1,144 @@
+# Lint Configuration Packages
+
+Capsule UI provides shareable configurations for both Stylelint and ESLint.
+These presets include the custom `capsule-ui/require-layer` rule and sensible
+defaults to encourage consistent styling practices.
+
+## Stylelint
+
+Install and extend the config:
+
+```sh
+pnpm add -D stylelint stylelint-config-capsule stylelint-declaration-strict-value
+```
+
+```js
+// stylelint.config.cjs
+module.exports = {
+  extends: ['stylelint-config-capsule']
+};
+```
+
+### Custom layer stacks
+
+The config enforces an `@layer components` declaration by default.  Override the
+rule to support different layer names:
+
+```js
+module.exports = {
+  extends: ['stylelint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': { names: ['components', 'utilities'] }
+  }
+};
+```
+
+Disable the rule entirely when layers are not required:
+
+```js
+module.exports = {
+  extends: ['stylelint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': null
+  }
+};
+```
+
+### Examples
+
+**Web Components**
+
+```js
+// stylelint.config.cjs
+module.exports = {
+  extends: ['stylelint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': { name: 'components' }
+  }
+};
+```
+
+**React components**
+
+```js
+// stylelint.config.cjs
+module.exports = {
+  extends: ['stylelint-config-capsule'],
+  rules: {
+    'capsule-ui/require-layer': { names: ['theme', 'components'] }
+  }
+};
+```
+
+## ESLint
+
+Install and extend the config:
+
+```sh
+pnpm add -D eslint eslint-config-capsule @typescript-eslint/parser
+```
+
+```js
+// .eslintrc.cjs
+module.exports = {
+  extends: ['eslint-config-capsule']
+};
+```
+
+### Allowing runtime styling libraries
+
+The preset blocks common runtime CSS-in-JS libraries.  Override the rule to
+permit specific libraries when needed:
+
+```js
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  overrides: [
+    {
+      files: ['src/**/*.{js,jsx,ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              { name: '@emotion/react' },
+              { name: '@emotion/styled' }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+};
+```
+
+### Examples
+
+**Web Components**
+
+```js
+// .eslintrc.cjs
+module.exports = {
+  extends: ['eslint-config-capsule']
+};
+```
+
+**Vue components**
+
+```js
+// .eslintrc.cjs
+module.exports = {
+  extends: ['eslint-config-capsule'],
+  overrides: [
+    {
+      files: ['src/components/**/*.{js,ts,vue}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          { paths: [] } // allow runtime styling libraries
+        ]
+      }
+    }
+  ]
+};
+```

--- a/packages/eslint-config-capsule/index.cjs
+++ b/packages/eslint-config-capsule/index.cjs
@@ -1,0 +1,50 @@
+module.exports = {
+  extends: ['eslint:recommended'],
+  env: {
+    es2021: true,
+    browser: true,
+    node: true
+  },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  overrides: [
+    {
+      files: ['**/*.{ts,tsx}'],
+      parser: '@typescript-eslint/parser'
+    },
+    {
+      files: ['**/*.{js,jsx,ts,tsx}'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              {
+                name: 'styled-components',
+                message: 'Runtime CSS-in-JS is not allowed in components.'
+              },
+              {
+                name: '@emotion/react',
+                message: 'Runtime CSS-in-JS is not allowed in components.'
+              },
+              {
+                name: '@emotion/styled',
+                message: 'Runtime CSS-in-JS is not allowed in components.'
+              },
+              {
+                name: 'aphrodite',
+                message: 'Runtime CSS-in-JS is not allowed in components.'
+              },
+              {
+                name: 'jss',
+                message: 'Runtime CSS-in-JS is not allowed in components.'
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/packages/eslint-config-capsule/package.json
+++ b/packages/eslint-config-capsule/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "eslint-config-capsule",
+  "version": "0.0.1",
+  "main": "index.cjs",
+  "files": ["index.cjs"],
+  "peerDependencies": {
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^8.39.1"
+  }
+}

--- a/packages/stylelint-config-capsule/index.cjs
+++ b/packages/stylelint-config-capsule/index.cjs
@@ -1,0 +1,31 @@
+const requireLayer = require('./require-layer.js').default;
+
+const layerEnv = process.env.CAPSULE_LAYER_NAMES;
+const layerRule =
+  layerEnv === 'off'
+    ? null
+    : layerEnv
+    ? { names: layerEnv.split(',').map((n) => n.trim()).filter(Boolean) }
+    : { name: 'components' };
+
+const rules = {
+  'selector-max-specificity': '0,1,0',
+  'scale-unlimited/declaration-strict-value': [
+    ['/color/', 'fill', 'stroke'],
+    {
+      ignoreValues: ['transparent', 'inherit', 'currentColor']
+    }
+  ]
+};
+
+if (layerRule) {
+  rules['capsule-ui/require-layer'] = layerRule;
+}
+
+module.exports = {
+  plugins: [
+    'stylelint-declaration-strict-value',
+    requireLayer
+  ],
+  rules
+};

--- a/packages/stylelint-config-capsule/package.json
+++ b/packages/stylelint-config-capsule/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "stylelint-config-capsule",
+  "version": "0.0.1",
+  "main": "index.cjs",
+  "files": ["index.cjs", "require-layer.js"],
+  "peerDependencies": {
+    "stylelint": "^15.10.0",
+    "stylelint-declaration-strict-value": "^1.10.2"
+  }
+}

--- a/packages/stylelint-config-capsule/require-layer.js
+++ b/packages/stylelint-config-capsule/require-layer.js
@@ -1,0 +1,90 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.messages = exports.ruleName = void 0;
+const stylelint_1 = __importDefault(require("stylelint"));
+exports.ruleName = 'capsule-ui/require-layer';
+/* eslint-enable no-unused-vars */
+const utils = stylelint_1.default.utils;
+exports.messages = utils.ruleMessages(exports.ruleName, {
+    expected: (name) => `Expected '@layer ${name}' declaration.`,
+});
+function getLineEnding(root) {
+    const css = root.source?.input.css;
+    return typeof utils.getLineEnding === 'function'
+        ? utils.getLineEnding(css)
+        : css && css.includes('\r\n')
+            ? '\r\n'
+            : '\n';
+}
+function isString(value) {
+    return typeof value === 'string';
+}
+function isStringArray(value) {
+    return Array.isArray(value) && value.every(isString);
+}
+const rule = (options = {}, _secondaryOption, context) => {
+    return (root, result) => {
+        const validOptions = utils.validateOptions(result, exports.ruleName, {
+            actual: options,
+            possible: {
+                name: [isString, isStringArray],
+                names: [isString, isStringArray],
+            },
+            optional: true,
+        });
+        if (!validOptions) {
+            return;
+        }
+        let expected = options.names || options.name || 'components';
+        if (!Array.isArray(expected)) {
+            expected = [expected];
+        }
+        const newline = getLineEnding(root);
+        let hasLayer = false;
+        root.walkAtRules('layer', (rule) => {
+            if (rule.parent !== root) {
+                return;
+            }
+            const layers = rule.params.split(',').map((l) => l.trim()).filter(Boolean);
+            if (expected.some((name) => layers.includes(name))) {
+                hasLayer = true;
+            }
+        });
+        if (!hasLayer) {
+            const first = expected[0];
+            if (context?.fix) {
+                let insertAfter = null;
+                const skip = new Set(['charset', 'import', 'namespace']);
+                for (const node of root.nodes ?? []) {
+                    if (node.type === 'comment' ||
+                        (node.type === 'atrule' && skip.has(node.name))) {
+                        insertAfter = node;
+                        continue;
+                    }
+                    break;
+                }
+                if (insertAfter) {
+                    insertAfter.after(`${newline}@layer ${first};${newline}`);
+                }
+                else {
+                    root.prepend(`@layer ${first};${newline}`);
+                    if (root.nodes[1]) {
+                        root.nodes[1].raws.before = root.nodes[1].raws.before || newline;
+                    }
+                }
+            }
+            else {
+                utils.report({
+                    ruleName: exports.ruleName,
+                    result,
+                    node: root,
+                    message: exports.messages.expected(first),
+                });
+            }
+        }
+    };
+};
+exports.default = stylelint_1.default.createPlugin(exports.ruleName, rule);


### PR DESCRIPTION
## Summary
- add `stylelint-config-capsule` with custom `capsule-ui/require-layer` rule
- add `eslint-config-capsule` that forbids runtime CSS-in-JS libraries
- document extending and overriding the new lint configurations

## Testing
- `pnpm test` *(fails: Could not find expected browser (chrome) locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb424620988328893fa118152a883c