### PR TITLE
feat: add select component wrappers

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -11,3 +11,4 @@ export const CapsInput = createComponent('caps-input');
 export const CapsCard = createComponent('caps-card');
 export const CapsTabs = createComponent('caps-tabs');
 export const CapsModal = createComponent('caps-modal');
+export const CapsSelect = createComponent('caps-select');

--- a/packages/svelte/Select.svelte
+++ b/packages/svelte/Select.svelte
@@ -1,0 +1,7 @@
+<script>
+  import '@capsule-ui/core';
+</script>
+
+<caps-select {...$$restProps}>
+  <slot />
+</caps-select>

--- a/packages/svelte/index.js
+++ b/packages/svelte/index.js
@@ -3,3 +3,4 @@ export { default as CapsInput } from './Input.svelte';
 export { default as CapsCard } from './Card.svelte';
 export { default as CapsTabs } from './Tabs.svelte';
 export { default as CapsModal } from './Modal.svelte';
+export { default as CapsSelect } from './Select.svelte';

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -14,3 +14,4 @@ export const CapsInput = createComponent('caps-input', 'CapsInput');
 export const CapsCard = createComponent('caps-card', 'CapsCard');
 export const CapsTabs = createComponent('caps-tabs', 'CapsTabs');
 export const CapsModal = createComponent('caps-modal', 'CapsModal');
+export const CapsSelect = createComponent('caps-select', 'CapsSelect');


### PR DESCRIPTION
## Summary
- export CapsSelect from React and Vue adapters
- add Svelte CapsSelect component and re-export it

## Testing
- `pnpm test` *(fails: Could not find expected browser (chrome) locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb492b70188328b0233b655d8b4a8e