### PR TITLE
docs: document token build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Shadow DOM v1, `::part`, and container queries are supported in all modern everg
 Capsule doesn’t bypass a11y—your components still need focus states, ARIA, contrast, keyboard handling, and reduced-motion respect. The isolation helps keep a11y styles consistent.
 
 ## Tokens
-Source tokens live in `tokens/source/tokens.json` using the W3C draft design tokens structure. Run `pnpm tokens:build` to generate `dist/tokens.css`, `dist/tokens.d.ts`, and `dist/tokens.json`. The CSS file exposes custom properties for light and dark themes; toggling `[data-theme="dark"]` on the page swaps the values.
+Source tokens live in `tokens/source/tokens.json` using the W3C draft design tokens structure. The build pipeline is implemented in [`scripts/build-tokens.ts`](./scripts/build-tokens.ts) and runs via `pnpm tokens:build` to generate `dist/tokens.css`, `dist/tokens.d.ts`, and `dist/tokens.json`. The CSS file exposes custom properties for light and dark themes; toggling `[data-theme="dark"]` on the page swaps the values.
 
 For development convenience, `pnpm tokens:watch` monitors `tokens/source/tokens.json` and rebuilds the output whenever it changes.
 

--- a/scripts/build-tokens.ts
+++ b/scripts/build-tokens.ts
@@ -1,3 +1,20 @@
+/**
+ * Build the design token artifacts used by Capsule UI.
+ *
+ * This script is what powers the `pnpm tokens:build` command. It reads the
+ * token definition JSON, validates it, and writes the generated CSS, JSON,
+ * JavaScript, and TypeScript outputs to the `dist/` directory so they are easy
+ * to inspect and extend.
+ *
+ * Run with:
+ *
+ * ```bash
+ * pnpm tokens:build [-- --default-theme=<theme>]
+ * ```
+ *
+ * Pass a `--default-theme` flag to control which theme's values populate the
+ * `:root` selector in the generated CSS.
+ */
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
## Summary
- clarify token build process with inline documentation
- link README to the build script for discoverability

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Could not find expected browser `chrome` locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb494866948328bc71402d6d16a1f5