### PR TITLE
feat: add framework SSR examples

### DIFF
--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -1,7 +1,8 @@
 # SSR Framework Examples
 
 This directory contains reference integrations for server-side rendering with React, Vue and Svelte.
-Each example renders a simple message on the server and hydrates on the client.
+Each example renders a Capsule button on the server, hydrates it on the client and
+demonstrates variant styling and basic accessibility attributes.
 
 ## Running an Example
 
@@ -12,4 +13,4 @@ pnpm install
 pnpm run dev
 ```
 
-Then visit `http://localhost:3000` in a browser to see the hydrated output.
+Then visit `http://localhost:3000` in a browser to see the hydrated Capsule component.

--- a/examples/ssr/react/App.js
+++ b/examples/ssr/react/App.js
@@ -1,5 +1,10 @@
 import React from 'react';
+import { CapsButton } from '@capsule-ui/react';
 
 export function App({ message }) {
-  return React.createElement('h1', null, message);
+  return React.createElement(
+    CapsButton,
+    { variant: 'ghost', 'aria-label': message },
+    message
+  );
 }

--- a/examples/ssr/react/package.json
+++ b/examples/ssr/react/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@capsule-ui/react": "file:../../packages/react",
+    "@capsule-ui/core": "file:../../packages/core"
   }
 }

--- a/examples/ssr/react/server.js
+++ b/examples/ssr/react/server.js
@@ -1,7 +1,11 @@
 import express from 'express';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { App } from './App.js';
+
+global.HTMLElement = class {};
+global.customElements = { define() {}, get() { return undefined; } };
+
+const { App } = await import('./App.js');
 
 const app = express();
 
@@ -17,6 +21,13 @@ app.get('/', (req, res) => {
 <head>
   <meta charset="UTF-8" />
   <title>React SSR Example</title>
+  <style>
+    caps-button[variant="ghost"]::part(button) {
+      background: transparent;
+      border: 1px solid #4f46e5;
+      color: #4f46e5;
+    }
+  </style>
 </head>
 <body>
   <div id="root">${appHtml}</div>

--- a/examples/ssr/svelte/App.svelte
+++ b/examples/ssr/svelte/App.svelte
@@ -1,5 +1,6 @@
 <script>
+  import { CapsButton } from '@capsule-ui/svelte';
   export let message;
 </script>
 
-<h1>{message}</h1>
+<CapsButton variant="ghost" aria-label={message}>{message}</CapsButton>

--- a/examples/ssr/svelte/package.json
+++ b/examples/ssr/svelte/package.json
@@ -7,6 +7,8 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "svelte": "^4.2.0"
+    "svelte": "^4.2.0",
+    "@capsule-ui/svelte": "file:../../packages/svelte",
+    "@capsule-ui/core": "file:../../packages/core"
   }
 }

--- a/examples/ssr/svelte/server.js
+++ b/examples/ssr/svelte/server.js
@@ -1,6 +1,10 @@
 import 'svelte/register';
 import express from 'express';
-import App from './App.svelte';
+
+global.HTMLElement = class {};
+global.customElements = { define() {}, get() { return undefined; } };
+
+const App = (await import('./App.svelte')).default;
 
 const app = express();
 
@@ -14,6 +18,13 @@ app.get('/', (req, res) => {
   <meta charset="UTF-8" />
   <title>Svelte SSR Example</title>
   ${head}
+  <style>
+    caps-button[variant="ghost"]::part(button) {
+      background: transparent;
+      border: 1px solid #4f46e5;
+      color: #4f46e5;
+    }
+  </style>
 </head>
 <body>
   <div id="svelte">${html}</div>

--- a/examples/ssr/vue/App.js
+++ b/examples/ssr/vue/App.js
@@ -1,8 +1,9 @@
 import { h } from 'vue';
+import { CapsButton } from '@capsule-ui/vue';
 
 export default {
   props: ['message'],
   render() {
-    return h('h1', this.message);
+    return h(CapsButton, { variant: 'ghost', 'aria-label': this.message }, this.message);
   }
 };

--- a/examples/ssr/vue/package.json
+++ b/examples/ssr/vue/package.json
@@ -8,6 +8,8 @@
   "dependencies": {
     "@vue/server-renderer": "^3.4.21",
     "express": "^4.18.2",
-    "vue": "^3.4.21"
+    "vue": "^3.4.21",
+    "@capsule-ui/vue": "file:../../packages/vue",
+    "@capsule-ui/core": "file:../../packages/core"
   }
 }

--- a/examples/ssr/vue/server.js
+++ b/examples/ssr/vue/server.js
@@ -1,7 +1,11 @@
 import express from 'express';
 import { createSSRApp } from 'vue';
 import { renderToString } from '@vue/server-renderer';
-import App from './App.js';
+
+global.HTMLElement = class {};
+global.customElements = { define() {}, get() { return undefined; } };
+
+const App = (await import('./App.js')).default;
 
 const app = express();
 
@@ -16,6 +20,13 @@ app.get('/', async (req, res) => {
 <head>
   <meta charset="UTF-8" />
   <title>Vue SSR Example</title>
+  <style>
+    caps-button[variant="ghost"]::part(button) {
+      background: transparent;
+      border: 1px solid #4f46e5;
+      color: #4f46e5;
+    }
+  </style>
 </head>
 <body>
   <div id="app">${appHtml}</div>


### PR DESCRIPTION
## Summary
- showcase server-rendered Capsule button in React, Vue and Svelte
- include variant styling and aria attributes in each example
- document running framework SSR demos

## Testing
- `pnpm test` *(fails: Could not find expected browser (chrome) locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4972799083288e38f4d06ace3ee2