### PR TITLE
docs: clarify governance flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Capsule works best with a few non-negotiables:
   - Disallow global element styling in component CSS.
   - Require `@layer components` in component CSS files; override the layer name with `CAPSULE_LAYER_NAMES="utilities,components"` or disable with `CAPSULE_LAYER_NAMES=off`.
 - **Build checks:** fail if runtime CSS-in-JS packages are imported in components (allow-list exceptions). Set `CAPSULE_ALLOW_RUNTIME_STYLES=true` to permit one-off dynamic styles and use CSS-in-JS only for cases that can’t be expressed with tokens or precompiled utilities.
+- **Governance flags:** `CAPSULE_LAYER_NAMES` and `CAPSULE_ALLOW_RUNTIME_STYLES` are escape hatches. Use them sparingly and see [governance flag guidelines](docs/governance-flags.md) for trade-offs and review practices.
 - Existing CSS-in-JS solutions can interoperate by generating token-based classes and injecting them into `@layer overrides`.
 - **Storybook + VRT:** each component shows theme × density × locale, with visual regression tests.
 ## Architecture Decision Records

--- a/docs/governance-flags.md
+++ b/docs/governance-flags.md
@@ -1,0 +1,29 @@
+# Governance Flags
+
+Capsule enforces a strict style contract through lint and build checks. Two environment flags act as escape hatches when that contract needs to bend:
+
+## `CAPSULE_LAYER_NAMES`
+Use this to override the required `@layer components` name or to supply additional layer names (e.g. `utilities,components`). Consider it when:
+
+- Integrating legacy CSS that already uses different layer names.
+- Building a utilities layer that must precede `components`.
+- Prototyping before a shared layer order is finalized.
+
+**Trade-offs:** Diverging layer names can fragment the contract and make components behave differently across teams. Misordered layers may hide bugs or allow unintended overrides.
+
+**Consistency tips:** document the chosen layer order in an ADR, share configuration across repos, and review custom layer names in code review.
+
+## `CAPSULE_ALLOW_RUNTIME_STYLES`
+Setting this flag allows runtime CSS-in-JS imports that Capsule normally blocks. Use it only when:
+
+- Styles must react to data that cannot be expressed with design tokens.
+- A third-party library injects styles at runtime.
+- Performing a temporary migration away from an existing CSS-in-JS solution.
+
+**Trade-offs:** runtime styling increases bundle size, skips static analysis, and can erode token discipline. Overuse leads to unpredictable styling and harder debugging.
+
+**Consistency tips:** require an ADR for each exception, scope dynamic styles to leaf components, and track these usages for eventual removal.
+
+---
+
+Bending Capsule's contract should be rare and deliberate. When these flags are used, capture the rationale, plan a path back to the default, and communicate decisions so teams stay aligned.


### PR DESCRIPTION
## Summary
- document governance flags and trade-offs
- link README to the new guidance

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb496ce49c8328b186415f5a90ecc2