### PR TITLE
feat: add framework adapters and css modules

### DIFF
--- a/docs/framework-adapters.md
+++ b/docs/framework-adapters.md
@@ -4,6 +4,30 @@ Capsule ships tiny wrappers so its Web Components fit naturally into
 popular frameworks. Each adapter forwards attributes and events and
 exposes the same Style API – CSS variables, `::part`, and attributes.
 
+Need just the styles? Import CSS Modules from each adapter's `/css`
+entry and use them like regular framework classes:
+
+```jsx
+import { button } from '@capsule-ui/react/css';
+<button className={button.button}>Save</button>;
+```
+
+```vue
+<script setup>
+import { button } from '@capsule-ui/vue/css';
+</script>
+
+<button :class="button.button">Save</button>
+```
+
+```svelte
+<script>
+  import { button } from '@capsule-ui/svelte/css';
+</script>
+
+<button class={button.button}>Save</button>
+```
+
 ## React
 
 ```bash

--- a/packages/react/css/index.d.ts
+++ b/packages/react/css/index.d.ts
@@ -1,0 +1,6 @@
+export const button: { readonly button: string };
+export const input: { readonly input: string };
+export const card: { readonly card: string };
+export const tabs: { readonly tabs: string };
+export const modal: { readonly modal: string };
+export const select: { readonly select: string };

--- a/packages/react/css/index.js
+++ b/packages/react/css/index.js
@@ -1,0 +1,8 @@
+import button from '@capsule-ui/core/button.module.css';
+import input from '@capsule-ui/core/input.module.css';
+import card from '@capsule-ui/core/card.module.css';
+import tabs from '@capsule-ui/core/tabs.module.css';
+import modal from '@capsule-ui/core/modal.module.css';
+import select from '@capsule-ui/core/select.module.css';
+
+export { button, input, card, tabs, modal, select };

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,10 +1,46 @@
-import { createElement, forwardRef } from 'react';
+import { createElement, forwardRef, useEffect, useRef } from 'react';
 import '@capsule-ui/core';
 
+const mergeRefs = (ref, node) => {
+  if (typeof ref === 'function') ref(node);
+  else if (ref) ref.current = node;
+};
+
 const createComponent = (tag) =>
-  forwardRef(({ children, ...rest }, ref) =>
-    createElement(tag, { ...rest, ref }, children)
-  );
+  forwardRef(({ children, ...props }, forwardedRef) => {
+    const innerRef = useRef(null);
+
+    useEffect(() => {
+      const el = innerRef.current;
+      if (!el) return;
+      const listeners = [];
+      for (const [key, value] of Object.entries(props)) {
+        if (key.startsWith('on') && typeof value === 'function') {
+          const evt = key.slice(2).toLowerCase();
+          el.addEventListener(evt, value);
+          listeners.push([evt, value]);
+        }
+      }
+      return () => {
+        listeners.forEach(([e, fn]) => el.removeEventListener(e, fn));
+      };
+    }, [props]);
+
+    const rest = {};
+    for (const [key, value] of Object.entries(props)) {
+      if (!(key.startsWith('on') && typeof value === 'function')) {
+        rest[key] = value;
+      }
+    }
+
+    return createElement(tag, {
+      ...rest,
+      ref: (node) => {
+        innerRef.current = node;
+        mergeRefs(forwardedRef, node);
+      }
+    }, children);
+  });
 
 export const CapsButton = createComponent('caps-button');
 export const CapsInput = createComponent('caps-input');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" }
+    ".": { "import": "./index.js" },
+    "./css": { "import": "./css/index.js" }
   },
   "peerDependencies": {
     "react": "^18.0.0"

--- a/packages/svelte/css/index.d.ts
+++ b/packages/svelte/css/index.d.ts
@@ -1,0 +1,6 @@
+export const button: { readonly button: string };
+export const input: { readonly input: string };
+export const card: { readonly card: string };
+export const tabs: { readonly tabs: string };
+export const modal: { readonly modal: string };
+export const select: { readonly select: string };

--- a/packages/svelte/css/index.js
+++ b/packages/svelte/css/index.js
@@ -1,0 +1,8 @@
+import button from '@capsule-ui/core/button.module.css';
+import input from '@capsule-ui/core/input.module.css';
+import card from '@capsule-ui/core/card.module.css';
+import tabs from '@capsule-ui/core/tabs.module.css';
+import modal from '@capsule-ui/core/modal.module.css';
+import select from '@capsule-ui/core/select.module.css';
+
+export { button, input, card, tabs, modal, select };

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" }
+    ".": { "import": "./index.js" },
+    "./css": { "import": "./css/index.js" }
   },
   "peerDependencies": {
     "svelte": "^4.0.0"

--- a/packages/vue/css/index.d.ts
+++ b/packages/vue/css/index.d.ts
@@ -1,0 +1,6 @@
+export const button: { readonly button: string };
+export const input: { readonly input: string };
+export const card: { readonly card: string };
+export const tabs: { readonly tabs: string };
+export const modal: { readonly modal: string };
+export const select: { readonly select: string };

--- a/packages/vue/css/index.js
+++ b/packages/vue/css/index.js
@@ -1,0 +1,8 @@
+import button from '@capsule-ui/core/button.module.css';
+import input from '@capsule-ui/core/input.module.css';
+import card from '@capsule-ui/core/card.module.css';
+import tabs from '@capsule-ui/core/tabs.module.css';
+import modal from '@capsule-ui/core/modal.module.css';
+import select from '@capsule-ui/core/select.module.css';
+
+export { button, input, card, tabs, modal, select };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" }
+    ".": { "import": "./index.js" },
+    "./css": { "import": "./css/index.js" }
   },
   "peerDependencies": {
     "vue": "^3.0.0"


### PR DESCRIPTION
## Summary
- forward React custom element events and export css modules
- expose `/css` entry points for React, Vue and Svelte adapters
- document css module usage examples

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Token 'spacing.bad' has invalid dimension value '10qq'; token artifacts out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4de1b5388328bccf70435c300c85