### PR TITLE
feat: add themeable design token pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,23 @@ Shadow DOM v1, `::part`, and container queries are supported in all modern everg
 Capsule doesn’t bypass a11y—your components still need focus states, ARIA, contrast, keyboard handling, and reduced-motion respect. The isolation helps keep a11y styles consistent.
 
 ## Tokens
-Source tokens live in `tokens/source/tokens.json` using the W3C draft design tokens structure. The build pipeline is implemented in [`scripts/build-tokens.ts`](./scripts/build-tokens.ts) and runs via `pnpm tokens:build` to generate `dist/tokens.css`, `dist/tokens.d.ts`, and `dist/tokens.json`. The CSS file exposes custom properties for light and dark themes; toggling `[data-theme="dark"]` on the page swaps the values.
+Source tokens live in `tokens/source/tokens.json` using the W3C draft design tokens structure. The build pipeline is implemented in [`scripts/build-tokens.ts`](./scripts/build-tokens.ts) and runs via `pnpm tokens:build` to generate `dist/tokens.css`, `dist/tokens.d.ts`, and `dist/tokens.json`. The CSS file exposes custom properties for the built-in `light`, `dark`, and `ocean` themes; toggling `[data-theme="dark"]` (or any other theme name) on the page swaps the values.
 
 For development convenience, `pnpm tokens:watch` monitors `tokens/source/tokens.json` and rebuilds the output whenever it changes.
+
+### Runtime theme switching
+
+Use helpers from `@capsule-ui/core` to switch themes by updating the `data-theme` attribute:
+
+```js
+import { setTheme, getTheme, onThemeChange } from '@capsule-ui/core';
+
+setTheme('dark'); // <html data-theme="dark">
+console.log(getTheme());
+const stop = onThemeChange(t => console.log('theme', t));
+```
+
+Add a new theme by defining values for it in `tokens/source/tokens.json` and rebuilding with `pnpm tokens:build`. Then call `setTheme('<name>')` or set `<html data-theme="<name>">` at runtime.
 
 ### Theming lab
 

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,20 +1,60 @@
 @layer components;
 :root{
   --color-background: #ffffff;
+  --color-border: #e5e7eb;
   --color-brand: #4f46e5;
+  --color-overlay: rgba(0,0,0,0.5);
+  --color-secondary: #6b7280;
   --color-text: #000000;
-  --good-token_1-inner_value: #000;
-  --spacing-lg: 16px;
-  --spacing-md: 8px;
-  --spacing-sm: 4px;
+  --motion-fast: 0.2s;
+  --radius-lg: 0.5rem;
+  --radius-md: 0.375rem;
+  --radius-sm: 0.25rem;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --spacing-2xl: 1.5rem;
+  --spacing-lg: 1rem;
+  --spacing-md: 0.75rem;
+  --spacing-sm: 0.5rem;
+  --spacing-xl: 1.25rem;
+  --spacing-xs: 0.25rem;
 }
 
 [data-theme="dark"]{
   --color-background: #000000;
+  --color-border: #4b5563;
   --color-brand: #6366f1;
+  --color-overlay: rgba(0,0,0,0.5);
+  --color-secondary: #9ca3af;
   --color-text: #ffffff;
-  --good-token_1-inner_value: #000;
-  --spacing-lg: 16px;
-  --spacing-md: 8px;
-  --spacing-sm: 4px;
+  --motion-fast: 0.2s;
+  --radius-lg: 0.5rem;
+  --radius-md: 0.375rem;
+  --radius-sm: 0.25rem;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --spacing-2xl: 1.5rem;
+  --spacing-lg: 1rem;
+  --spacing-md: 0.75rem;
+  --spacing-sm: 0.5rem;
+  --spacing-xl: 1.25rem;
+  --spacing-xs: 0.25rem;
+}
+
+[data-theme="ocean"]{
+  --color-background: #f0f9ff;
+  --color-border: #7dd3fc;
+  --color-brand: #0284c7;
+  --color-overlay: rgba(0,0,0,0.5);
+  --color-secondary: #475569;
+  --color-text: #0f172a;
+  --motion-fast: 0.2s;
+  --radius-lg: 0.5rem;
+  --radius-md: 0.375rem;
+  --radius-sm: 0.25rem;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --spacing-2xl: 1.5rem;
+  --spacing-lg: 1rem;
+  --spacing-md: 0.75rem;
+  --spacing-sm: 0.5rem;
+  --spacing-xl: 1.25rem;
+  --spacing-xs: 0.25rem;
 }

--- a/dist/tokens.d.ts
+++ b/dist/tokens.d.ts
@@ -1,5 +1,5 @@
-export type ThemeName = 'dark' | 'light';
-export type TokenName = '--color-background' | '--color-brand' | '--color-text' | '--good-token_1-inner_value' | '--spacing-lg' | '--spacing-md' | '--spacing-sm';
+export type ThemeName = 'dark' | 'light' | 'ocean';
+export type TokenName = '--color-background' | '--color-border' | '--color-brand' | '--color-overlay' | '--color-secondary' | '--color-text' | '--motion-fast' | '--radius-lg' | '--radius-md' | '--radius-sm' | '--shadow-sm' | '--spacing-2xl' | '--spacing-lg' | '--spacing-md' | '--spacing-sm' | '--spacing-xl' | '--spacing-xs';
 export type TokenValues = Record<ThemeName, string | number>;
 export const tokens: Record<TokenName, TokenValues>;
 export default tokens;

--- a/dist/tokens.js
+++ b/dist/tokens.js
@@ -1,31 +1,88 @@
 export const tokens = {
   "--color-background": {
     "dark": "#000000",
-    "light": "#ffffff"
+    "light": "#ffffff",
+    "ocean": "#f0f9ff"
+  },
+  "--color-border": {
+    "dark": "#4b5563",
+    "light": "#e5e7eb",
+    "ocean": "#7dd3fc"
   },
   "--color-brand": {
     "dark": "#6366f1",
-    "light": "#4f46e5"
+    "light": "#4f46e5",
+    "ocean": "#0284c7"
+  },
+  "--color-overlay": {
+    "dark": "rgba(0,0,0,0.5)",
+    "light": "rgba(0,0,0,0.5)",
+    "ocean": "rgba(0,0,0,0.5)"
+  },
+  "--color-secondary": {
+    "dark": "#9ca3af",
+    "light": "#6b7280",
+    "ocean": "#475569"
   },
   "--color-text": {
     "dark": "#ffffff",
-    "light": "#000000"
+    "light": "#000000",
+    "ocean": "#0f172a"
   },
-  "--good-token_1-inner_value": {
-    "dark": "#000",
-    "light": "#000"
+  "--motion-fast": {
+    "dark": "0.2s",
+    "light": "0.2s",
+    "ocean": "0.2s"
+  },
+  "--radius-lg": {
+    "dark": "0.5rem",
+    "light": "0.5rem",
+    "ocean": "0.5rem"
+  },
+  "--radius-md": {
+    "dark": "0.375rem",
+    "light": "0.375rem",
+    "ocean": "0.375rem"
+  },
+  "--radius-sm": {
+    "dark": "0.25rem",
+    "light": "0.25rem",
+    "ocean": "0.25rem"
+  },
+  "--shadow-sm": {
+    "dark": "0 1px 2px rgba(0,0,0,0.05)",
+    "light": "0 1px 2px rgba(0,0,0,0.05)",
+    "ocean": "0 1px 2px rgba(0,0,0,0.05)"
+  },
+  "--spacing-2xl": {
+    "dark": "1.5rem",
+    "light": "1.5rem",
+    "ocean": "1.5rem"
   },
   "--spacing-lg": {
-    "dark": "16px",
-    "light": "16px"
+    "dark": "1rem",
+    "light": "1rem",
+    "ocean": "1rem"
   },
   "--spacing-md": {
-    "dark": "8px",
-    "light": "8px"
+    "dark": "0.75rem",
+    "light": "0.75rem",
+    "ocean": "0.75rem"
   },
   "--spacing-sm": {
-    "dark": "4px",
-    "light": "4px"
+    "dark": "0.5rem",
+    "light": "0.5rem",
+    "ocean": "0.5rem"
+  },
+  "--spacing-xl": {
+    "dark": "1.25rem",
+    "light": "1.25rem",
+    "ocean": "1.25rem"
+  },
+  "--spacing-xs": {
+    "dark": "0.25rem",
+    "light": "0.25rem",
+    "ocean": "0.25rem"
   }
 };
 export default tokens;

--- a/dist/tokens.json
+++ b/dist/tokens.json
@@ -1,30 +1,87 @@
 {
   "--color-background": {
     "dark": "#000000",
-    "light": "#ffffff"
+    "light": "#ffffff",
+    "ocean": "#f0f9ff"
+  },
+  "--color-border": {
+    "dark": "#4b5563",
+    "light": "#e5e7eb",
+    "ocean": "#7dd3fc"
   },
   "--color-brand": {
     "dark": "#6366f1",
-    "light": "#4f46e5"
+    "light": "#4f46e5",
+    "ocean": "#0284c7"
+  },
+  "--color-overlay": {
+    "dark": "rgba(0,0,0,0.5)",
+    "light": "rgba(0,0,0,0.5)",
+    "ocean": "rgba(0,0,0,0.5)"
+  },
+  "--color-secondary": {
+    "dark": "#9ca3af",
+    "light": "#6b7280",
+    "ocean": "#475569"
   },
   "--color-text": {
     "dark": "#ffffff",
-    "light": "#000000"
+    "light": "#000000",
+    "ocean": "#0f172a"
   },
-  "--good-token_1-inner_value": {
-    "dark": "#000",
-    "light": "#000"
+  "--motion-fast": {
+    "dark": "0.2s",
+    "light": "0.2s",
+    "ocean": "0.2s"
+  },
+  "--radius-lg": {
+    "dark": "0.5rem",
+    "light": "0.5rem",
+    "ocean": "0.5rem"
+  },
+  "--radius-md": {
+    "dark": "0.375rem",
+    "light": "0.375rem",
+    "ocean": "0.375rem"
+  },
+  "--radius-sm": {
+    "dark": "0.25rem",
+    "light": "0.25rem",
+    "ocean": "0.25rem"
+  },
+  "--shadow-sm": {
+    "dark": "0 1px 2px rgba(0,0,0,0.05)",
+    "light": "0 1px 2px rgba(0,0,0,0.05)",
+    "ocean": "0 1px 2px rgba(0,0,0,0.05)"
+  },
+  "--spacing-2xl": {
+    "dark": "1.5rem",
+    "light": "1.5rem",
+    "ocean": "1.5rem"
   },
   "--spacing-lg": {
-    "dark": "16px",
-    "light": "16px"
+    "dark": "1rem",
+    "light": "1rem",
+    "ocean": "1rem"
   },
   "--spacing-md": {
-    "dark": "8px",
-    "light": "8px"
+    "dark": "0.75rem",
+    "light": "0.75rem",
+    "ocean": "0.75rem"
   },
   "--spacing-sm": {
-    "dark": "4px",
-    "light": "4px"
+    "dark": "0.5rem",
+    "light": "0.5rem",
+    "ocean": "0.5rem"
+  },
+  "--spacing-xl": {
+    "dark": "1.25rem",
+    "light": "1.25rem",
+    "ocean": "1.25rem"
+  },
+  "--spacing-xs": {
+    "dark": "0.25rem",
+    "light": "0.25rem",
+    "ocean": "0.25rem"
   }
 }

--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -14,30 +14,30 @@ class CapsButton extends HTMLElement {
 
         button {
           font: inherit;
-          padding: 0.5rem 1rem;
+          padding: var(--spacing-sm) var(--spacing-lg);
           border: none;
-          border-radius: 0.375rem;
-          background: var(--caps-btn-bg, #4f46e5);
-          color: var(--caps-btn-color, #fff);
-          transition: background var(--caps-motion), color var(--caps-motion);
+          border-radius: var(--radius-md);
+          background: var(--color-brand);
+          color: var(--color-text);
+          transition: background var(--motion-fast), color var(--motion-fast);
         }
         :host([variant="outline"]) button {
           background: transparent;
-          border: 1px solid var(--caps-btn-bg, #4f46e5);
-          color: var(--caps-btn-bg, #4f46e5);
+          border: 1px solid var(--color-brand);
+          color: var(--color-brand);
         }
         @container (min-width: 480px) {
-          button { padding: 0.75rem 1.25rem; }
+          button { padding: var(--spacing-md) var(--spacing-xl); }
         }
-        button:focus-visible { outline: 2px solid #000; outline-offset: 2px; }
+        button:focus-visible { outline: 2px solid var(--color-text); outline-offset: 2px; }
         button[disabled] { opacity: 0.6; cursor: not-allowed; }
         @media (prefers-reduced-motion: reduce) {
-          :host { --caps-motion: 0s; }
+          :host { --motion-fast: 0s; }
         }
         @media (prefers-contrast: more) {
           button {
-            background: var(--caps-btn-bg-contrast, #000);
-            color: var(--caps-btn-color-contrast, #fff);
+            background: var(--color-text);
+            color: var(--color-background);
           }
         }
       </style>

--- a/packages/core/button.module.css
+++ b/packages/core/button.module.css
@@ -1,25 +1,24 @@
 @layer components;
 .button {
   font: inherit;
-  padding: 0.5rem 1rem;
+  padding: var(--spacing-sm) var(--spacing-lg);
   border: none;
-  border-radius: 0.375rem;
-  background: var(--caps-btn-bg, #4f46e5);
-  color: var(--caps-btn-color, #fff);
+  border-radius: var(--radius-md);
+  background: var(--color-brand);
+  color: var(--color-text);
   container-type: inline-size;
 }
 .button:where([data-variant="outline"]) {
   background: transparent;
-  border: 1px solid var(--caps-btn-bg, #4f46e5);
-  color: var(--caps-btn-bg, #4f46e5);
+  border: 1px solid var(--color-brand);
+  color: var(--color-brand);
 }
 @container (min-width: 480px) {
-  .button { padding: 0.75rem 1.25rem; }
-  transition: background var(--caps-motion, 0.2s), color var(--caps-motion, 0.2s);
+  .button { padding: var(--spacing-md) var(--spacing-xl); }
+  transition: background var(--motion-fast), color var(--motion-fast);
 }
 .button:where(:focus-visible) {
-  outline: 2px solid;
-  outline-color: var(--color-text);
+  outline: 2px solid var(--color-text);
   outline-offset: 2px;
 }
 .button:where(:disabled) {
@@ -32,22 +31,22 @@
 }
 @media (prefers-contrast: more) {
   .button {
-    background: var(--caps-btn-bg-contrast, #000);
-    color: var(--caps-btn-color-contrast, #fff);
+    background: var(--color-text);
+    color: var(--color-background);
   }
+}
 
 /* size variants */
 .size-sm {
-  padding: 0.25rem 0.5rem;
+  padding: var(--spacing-xs) var(--spacing-sm);
 }
 
 .size-lg {
-  padding: 0.75rem 1.5rem;
+  padding: var(--spacing-md) var(--spacing-2xl);
 }
 
 /* visual variants */
 .variant-secondary {
-  background: var(--caps-btn-secondary-bg, #6b7280);
-  color: var(--caps-btn-secondary-color, #fff);
-
+  background: var(--color-secondary);
+  color: var(--color-text);
 }

--- a/packages/core/card.js
+++ b/packages/core/card.js
@@ -9,15 +9,15 @@ class CapsCard extends HTMLElement {
           container-type: inline-size;
         }
         .card {
-          background: var(--caps-card-bg, #fff);
-          border: var(--caps-card-border, 1px solid #e5e7eb);
-          border-radius: var(--caps-card-radius, 0.5rem);
-          padding: var(--caps-card-padding, 1rem);
-          box-shadow: var(--caps-card-shadow, 0 1px 2px rgba(0,0,0,0.05));
+          background: var(--color-background);
+          border: 1px solid var(--color-border);
+          border-radius: var(--radius-lg);
+          padding: var(--spacing-lg);
+          box-shadow: var(--shadow-sm);
         }
         :host([variant="outline"]) .card { box-shadow: none; }
         @container (min-width: 600px) {
-          .card { padding: calc(var(--caps-card-padding, 1rem) * 1.5); }
+          .card { padding: calc(var(--spacing-lg) * 1.5); }
         }
       </style>
       <div class="card" part="card"><slot></slot></div>

--- a/packages/core/card.module.css
+++ b/packages/core/card.module.css
@@ -1,15 +1,15 @@
 @layer components;
 .card {
-  background: var(--caps-card-bg, #fff);
-  border: var(--caps-card-border, 1px solid #e5e7eb);
-  border-radius: var(--caps-card-radius, 0.5rem);
-  padding: var(--caps-card-padding, 1rem);
-  box-shadow: var(--caps-card-shadow, 0 1px 2px rgba(0,0,0,0.05));
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
   container-type: inline-size;
 }
 .card:where([data-variant="outline"]) {
   box-shadow: none;
 }
 @container (min-width: 600px) {
-  .card { padding: calc(var(--caps-card-padding, 1rem) * 1.5); }
+  .card { padding: calc(var(--spacing-lg) * 1.5); }
 }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -7,3 +7,4 @@ export { CapsModal } from './modal.js';
 export { CapsSelect } from './select.js';
 export { getLocale, setLocale, onLocaleChange, formatNumber, formatDate, setDirection } from './locale.js';
 export { ThemeManager } from './theme-manager.js';
+export { setTheme, getTheme, onThemeChange } from './theme.js';

--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -12,26 +12,26 @@ class CapsInput extends HTMLElement {
         }
         input {
           font: inherit;
-          padding: 0.5rem 0.75rem;
-          border: 1px solid var(--caps-input-border, #d1d5db);
-          border-radius: 0.375rem;
-          background: var(--caps-input-bg, #fff);
-          color: var(--caps-input-color, #0f172a);
-          transition: border-color var(--caps-motion);
+          padding: var(--spacing-sm) var(--spacing-md);
+          border: 1px solid var(--color-border);
+          border-radius: var(--radius-md);
+          background: var(--color-background);
+          color: var(--color-text);
+          transition: border-color var(--motion-fast);
         }
         :host([variant="outline"]) input { background: transparent; }
         @container (min-width: 480px) {
-          input { padding: 0.75rem 1rem; }
+          input { padding: var(--spacing-md) var(--spacing-lg); }
         }
-        input:focus-visible { outline: 2px solid #4f46e5; outline-offset: 2px; }
+        input:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 2px; }
         @media (prefers-reduced-motion: reduce) {
-          :host { --caps-motion: 0s; }
+          :host { --motion-fast: 0s; }
         }
         @media (prefers-contrast: more) {
           input {
-            border-color: var(--caps-input-border-contrast, #000);
-            background: var(--caps-input-bg-contrast, #fff);
-            color: var(--caps-input-color-contrast, #000);
+            border-color: var(--color-text);
+            background: var(--color-background);
+            color: var(--color-text);
           }
         }
       </style>

--- a/packages/core/input.module.css
+++ b/packages/core/input.module.css
@@ -1,19 +1,19 @@
 @layer components;
 .input {
   font: inherit;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-brand);
-  border-radius: 0.375rem;
-  background: var(--caps-input-bg, #fff);
-  color: var(--caps-input-color, #0f172a);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-text);
   container-type: inline-size;
+  transition: border-color var(--motion-fast);
 }
 .input:where([data-variant="outline"]) {
   background: transparent;
 }
 @container (min-width: 480px) {
-  .input { padding: 0.75rem 1rem; }
-  transition: border-color var(--caps-motion, 0.2s);
+  .input { padding: var(--spacing-md) var(--spacing-lg); }
 }
 .input:where(:focus-visible) {
   outline: 2px solid;
@@ -25,8 +25,8 @@
 }
 @media (prefers-contrast: more) {
   .input {
-    border-color: var(--caps-input-border-contrast, #000);
-    background: var(--caps-input-bg-contrast, #fff);
-    color: var(--caps-input-color-contrast, #000);
+    border-color: var(--color-text);
+    background: var(--color-background);
+    color: var(--color-text);
   }
 }

--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -15,15 +15,15 @@ class CapsModal extends HTMLElement {
           container-type: inline-size;
         }
         :host([open]) { display: block; }
-        .backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.5); }
+        .backdrop { position: absolute; inset: 0; background: var(--color-overlay); }
         .modal {
           position: absolute;
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%);
-          background: var(--caps-modal-bg, #fff);
-          padding: 1rem;
-          border-radius: 0.5rem;
+          background: var(--color-background);
+          padding: var(--spacing-lg);
+          border-radius: var(--radius-lg);
           min-width: 300px;
         }
         :host([variant="fullscreen"]) .modal {

--- a/packages/core/modal.module.css
+++ b/packages/core/modal.module.css
@@ -4,7 +4,7 @@
   position: fixed;
   inset: 0;
   container-type: inline-size;
-  --caps-motion: 0.2s;
+  --motion-fast: 0.2s;
 }
 .container:where([open]) {
   display: block;
@@ -12,8 +12,7 @@
 .backdrop {
   position: absolute;
   inset: 0;
-  background: var(--color-text);
-  opacity: 0.5;
+  background: var(--color-overlay);
 }
 .modal {
   position: absolute;
@@ -21,17 +20,17 @@
   left: 50%;
   transform: translate(-50%, -50%);
   background: var(--color-background);
-  padding: 1rem;
-  border-radius: 0.5rem;
+  padding: var(--spacing-lg);
+  border-radius: var(--radius-lg);
   min-width: 300px;
-  transition: transform var(--caps-motion);
+  transition: transform var(--motion-fast);
 }
 @media (prefers-reduced-motion: reduce) {
-  .container { --caps-motion: 0s; }
+  .container { --motion-fast: 0s; }
 }
 @media (prefers-contrast: more) {
-  .backdrop { background: rgba(0,0,0,0.8); }
-  .modal { background: var(--caps-modal-bg-contrast, #fff); color: var(--caps-modal-color-contrast, #000); }
+  .backdrop { background: var(--color-overlay); }
+  .modal { background: var(--color-background); color: var(--color-text); }
 }
 :where(.container[data-variant="fullscreen"]) .modal {
   inset: 0;

--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -14,26 +14,26 @@ class CapsSelect extends HTMLElement {
         }
         select {
           font: inherit;
-          padding: var(--caps-select-padding, 0.5rem 0.75rem);
-          border: var(--caps-select-border, 1px solid #d1d5db);
-          border-radius: var(--caps-select-radius, 0.375rem);
-          background: var(--caps-select-bg, #fff);
-          color: var(--caps-select-color, #0f172a);
-          transition: border-color var(--caps-motion);
+          padding: var(--spacing-sm) var(--spacing-md);
+          border: 1px solid var(--color-border);
+          border-radius: var(--radius-md);
+          background: var(--color-background);
+          color: var(--color-text);
+          transition: border-color var(--motion-fast);
         }
         :host([variant="outline"]) select { background: transparent; }
         @container (min-width: 480px) {
-          select { padding: 0.75rem 1rem; }
+          select { padding: var(--spacing-md) var(--spacing-lg); }
         }
-        select:focus-visible { outline: 2px solid #4f46e5; outline-offset: 2px; }
+        select:focus-visible { outline: 2px solid var(--color-brand); outline-offset: 2px; }
         @media (prefers-reduced-motion: reduce) {
-          :host { --caps-motion: 0s; }
+          :host { --motion-fast: 0s; }
         }
         @media (prefers-contrast: more) {
           select {
-            border: var(--caps-select-border-contrast, 1px solid #000);
-            background: var(--caps-select-bg-contrast, #fff);
-            color: var(--caps-select-color-contrast, #000);
+            border: 1px solid var(--color-text);
+            background: var(--color-background);
+            color: var(--color-text);
           }
         }
       </style>

--- a/packages/core/select.module.css
+++ b/packages/core/select.module.css
@@ -1,19 +1,19 @@
 @layer components;
 .select {
   font: inherit;
-  padding: var(--caps-select-padding, 0.5rem 0.75rem);
-  border: var(--caps-select-border, 1px solid #d1d5db);
-  border-radius: var(--caps-select-radius, 0.375rem);
-  background: var(--caps-select-bg, #fff);
-  color: var(--caps-select-color, #0f172a);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+  color: var(--color-text);
   container-type: inline-size;
+  transition: border-color var(--motion-fast);
 }
 .select:where([data-variant="outline"]) {
   background: transparent;
 }
 @container (min-width: 480px) {
-  .select { padding: 0.75rem 1rem; }
-  transition: border-color var(--caps-motion, 0.2s);
+  .select { padding: var(--spacing-md) var(--spacing-lg); }
 }
 .select:where(:focus-visible) {
   outline: 2px solid;
@@ -25,8 +25,8 @@
 }
 @media (prefers-contrast: more) {
   .select {
-    border: var(--caps-select-border-contrast, 1px solid #000);
-    background: var(--caps-select-bg-contrast, #fff);
-    color: var(--caps-select-color-contrast, #000);
+    border: 1px solid var(--color-text);
+    background: var(--color-background);
+    color: var(--color-text);
   }
 }

--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -10,35 +10,40 @@ class CapsTabs extends HTMLElement {
           display: block;
           container-type: inline-size;
         }
-        .tablist { display: flex; gap: 0.25rem; }
+        .tablist { display: flex; gap: var(--spacing-xs); }
         .tablist ::slotted(button) {
-          background: var(--caps-tab-bg, transparent);
+          background: transparent;
           border: none;
-          padding: 0.5rem 0.75rem;
-          border-radius: 0.375rem 0.375rem 0 0;
+          padding: var(--spacing-sm) var(--spacing-md);
+          border-radius: var(--radius-md) var(--radius-md) 0 0;
           cursor: pointer;
-          transition: background var(--caps-motion);
+          transition: background var(--motion-fast);
         }
         :host([variant="pill"]) .tablist ::slotted(button) {
           border-radius: 999px;
         }
         .tablist ::slotted(button[aria-selected='true']) {
-          background: var(--caps-tab-active-bg, #fff);
+          background: var(--color-background);
           font-weight: 600;
         }
-        .panels { border: 1px solid var(--caps-tab-border, #e5e7eb); border-radius: 0 0 0.375rem 0.375rem; padding: 1rem; }
+        .panels {
+          border: 1px solid var(--color-border);
+          border-radius: 0 0 var(--radius-md) var(--radius-md);
+          padding: var(--spacing-lg);
+        }
         .panels ::slotted(*) { display: none; }
         .panels ::slotted([data-active]) { display: block; }
         @container (max-width: 480px) {
           .tablist { flex-direction: column; }
-          .tablist ::slotted(button) { border-radius: 0.375rem; }
+          .tablist ::slotted(button) { border-radius: var(--radius-md); }
+        }
         @media (prefers-reduced-motion: reduce) {
-          :host { --caps-motion: 0s; }
+          :host { --motion-fast: 0s; }
         }
         @media (prefers-contrast: more) {
           .tablist ::slotted(button[aria-selected='true']) {
-            background: var(--caps-tab-active-bg-contrast, #000);
-            color: var(--caps-tab-active-color-contrast, #fff);
+            background: var(--color-text);
+            color: var(--color-background);
           }
         }
       </style>

--- a/packages/core/tabs.module.css
+++ b/packages/core/tabs.module.css
@@ -4,18 +4,18 @@
 }
 .tablist {
   display: flex;
-  gap: 0.25rem;
+  gap: var(--spacing-xs);
 }
 .tab {
   background: transparent;
   border: none;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.375rem 0.375rem 0 0;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   cursor: pointer;
-  transition: background var(--caps-motion, 0.2s);
+  transition: background var(--motion-fast);
 }
 .tab:where(:focus-visible) {
-  outline: 2px solid #000;
+  outline: 2px solid var(--color-text);
   outline-offset: 2px;
 }
 :where(.tabs[data-variant="pill"]) .tab {
@@ -26,9 +26,9 @@
   font-weight: 600;
 }
 .panels {
-  border: 1px solid var(--color-brand);
-  border-radius: 0 0 0.375rem 0.375rem;
-  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  padding: var(--spacing-lg);
 }
 .panel {
   display: none;
@@ -38,13 +38,14 @@
 }
 @container (max-width: 480px) {
   .tablist { flex-direction: column; }
-  .tab { border-radius: 0.375rem; }
+  .tab { border-radius: var(--radius-md); }
+}
 @media (prefers-reduced-motion: reduce) {
   .tab { transition: none; }
 }
 @media (prefers-contrast: more) {
   .tab:where([aria-selected='true']) {
-    background: var(--caps-tab-active-bg-contrast, #000);
-    color: var(--caps-tab-active-color-contrast, #fff);
+    background: var(--color-text);
+    color: var(--color-background);
   }
 }

--- a/packages/core/theme.js
+++ b/packages/core/theme.js
@@ -1,0 +1,19 @@
+let current = 'light';
+
+export function getTheme(el = typeof document !== 'undefined' ? document.documentElement : undefined) {
+  if (!el) return current;
+  return el.getAttribute('data-theme') || current;
+}
+
+export function setTheme(theme, el = typeof document !== 'undefined' ? document.documentElement : undefined) {
+  if (!el) return;
+  el.setAttribute('data-theme', theme);
+  current = theme;
+}
+
+export function onThemeChange(callback, el = typeof document !== 'undefined' ? document.documentElement : undefined) {
+  if (!el) return () => {};
+  const observer = new MutationObserver(() => callback(getTheme(el)));
+  observer.observe(el, { attributes: true, attributeFilter: ['data-theme'] });
+  return () => observer.disconnect();
+}

--- a/scripts/token-validators.ts
+++ b/scripts/token-validators.ts
@@ -55,5 +55,14 @@ export const validators: Record<string, Validator> = {
     if (!isTime) {
       throw new Error(`Token '${name}' has invalid duration value '${value}'`);
     }
+  },
+  shadow: (name, value) => {
+    if (typeof value !== 'string') {
+      throw new Error(`Token '${name}' has invalid shadow value '${value}'`);
+    }
+    const match = csstree.lexer.matchProperty('box-shadow', value);
+    if (match.error) {
+      throw new Error(`Token '${name}' has invalid shadow value '${value}'`);
+    }
   }
 };

--- a/tests/build-tokens.test.js
+++ b/tests/build-tokens.test.js
@@ -440,7 +440,7 @@ test('generates type declarations for tokens', { concurrency: false }, async () 
       assert.match(dts, new RegExp(name));
     }
 
-    assert.match(dts, /export type ThemeName = 'dark' \| 'light';/);
+    assert.match(dts, /export type ThemeName = 'dark' \| 'light' \| 'ocean';/);
     assert.match(dts, /export type TokenValues = Record<ThemeName, string \| number>;/);
   } finally {
     await fs.writeFile(tokensPath, original);
@@ -458,6 +458,7 @@ test('generates JavaScript module for tokens', { concurrency: false }, async () 
     assert.deepEqual(mod.default['--color-background'], {
       light: '#ffffff',
       dark: '#000000',
+      ocean: '#f0f9ff',
     });
   } finally {
     await fs.writeFile(tokensPath, original);

--- a/tokens/source/tokens.json
+++ b/tokens/source/tokens.json
@@ -1,36 +1,71 @@
 {
-  "good-token_1": {
-    "inner_value": {
-      "$type": "color",
-      "$value": "#000"
-    }
-  },
   "color": {
     "background": {
       "$type": "color",
       "$value": {
         "light": "#ffffff",
-        "dark": "#000000"
+        "dark": "#000000",
+        "ocean": "#f0f9ff"
       }
     },
     "text": {
       "$type": "color",
       "$value": {
         "light": "#000000",
-        "dark": "#ffffff"
+        "dark": "#ffffff",
+        "ocean": "#0f172a"
       }
     },
     "brand": {
       "$type": "color",
       "$value": {
         "light": "#4f46e5",
-        "dark": "#6366f1"
+        "dark": "#6366f1",
+        "ocean": "#0284c7"
+      }
+    },
+    "secondary": {
+      "$type": "color",
+      "$value": {
+        "light": "#6b7280",
+        "dark": "#9ca3af",
+        "ocean": "#475569"
+      }
+    },
+    "border": {
+      "$type": "color",
+      "$value": {
+        "light": "#e5e7eb",
+        "dark": "#4b5563",
+        "ocean": "#7dd3fc"
+      }
+    },
+    "overlay": {
+      "$type": "color",
+      "$value": {
+        "light": "rgba(0,0,0,0.5)",
+        "dark": "rgba(0,0,0,0.5)",
+        "ocean": "rgba(0,0,0,0.5)"
       }
     }
   },
   "spacing": {
-    "sm": { "$type": "dimension", "$value": "4px" },
-    "md": { "$type": "dimension", "$value": "8px" },
-    "lg": { "$type": "dimension", "$value": "16px" }
+    "xs": { "$type": "dimension", "$value": "0.25rem" },
+    "sm": { "$type": "dimension", "$value": "0.5rem" },
+    "md": { "$type": "dimension", "$value": "0.75rem" },
+    "lg": { "$type": "dimension", "$value": "1rem" },
+    "xl": { "$type": "dimension", "$value": "1.25rem" },
+    "2xl": { "$type": "dimension", "$value": "1.5rem" }
+  },
+  "radius": {
+    "sm": { "$type": "dimension", "$value": "0.25rem" },
+    "md": { "$type": "dimension", "$value": "0.375rem" },
+    "lg": { "$type": "dimension", "$value": "0.5rem" }
+  },
+  "motion": {
+    "fast": { "$type": "duration", "$value": "0.2s" }
+  },
+  "shadow": {
+    "sm": { "$type": "shadow", "$value": "0 1px 2px rgba(0,0,0,0.05)" }
   }
 }

--- a/tokens/token.schema.json
+++ b/tokens/token.schema.json
@@ -22,7 +22,8 @@
             "number",
             "font-size",
             "font-weight",
-            "duration"
+            "duration",
+            "shadow"
           ]
         },
         "$value": {


### PR DESCRIPTION
## Summary
- define W3C-style tokens and generate CSS/TS/JSON artifacts
- add light, dark and ocean themes with runtime theme API
- refactor components to read from generated design tokens

## Testing
- `pnpm test` *(fails: Could not find expected browser (chrome) locally)*

------
https://chatgpt.com/codex/tasks/task_e_68bb572cf488832881dafb2121ddf8ed