### PR TITLE
feat: add sanitization utilities and security docs

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,29 @@
+# Security Guidelines
+
+Capsule UI components run inside Shadow DOM to encapsulate markup and styles. This isolation helps prevent style leakage but it does not replace defensive coding practices.
+
+## Input and Attribute Validation
+
+- Components only react to a known list of attributes. Unknown attributes are ignored.
+- Slotted or light‑DOM content passed into components is sanitised to remove `<script>` elements and inline event handlers.
+- When inserting HTML strings at runtime, use the exported `sanitizeHTML` or `sanitizeNode` helpers to clean untrusted content.
+
+## Event Surfaces
+
+Custom events emitted by components never evaluate string payloads. Consumers should always attach listeners using `addEventListener` rather than inline `on*` handlers, which are stripped during sanitisation.
+
+## Content Security Policy
+
+To minimise the risk of cross‑site scripting, configure a Content Security Policy similar to:
+
+```
+default-src 'self';
+script-src 'self';
+style-src 'self' 'unsafe-inline';
+```
+
+Adjust the directives for your environment and add `img-src`, `font-src`, or `connect-src` as required. Using nonces or hashes for styles and scripts enables a stricter policy if inline code must be avoided.
+
+## Further Review
+
+For high assurance deployments, engage a security professional to audit the component library and host application.

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -8,3 +8,4 @@ export { CapsSelect } from './select.js';
 export { getLocale, setLocale, onLocaleChange, formatNumber, formatDate, setDirection } from './locale.js';
 export { ThemeManager } from './theme-manager.js';
 export { setTheme, getTheme, onThemeChange } from './theme.js';
+export { sanitizeNode, sanitizeHTML } from './sanitize.js';

--- a/packages/core/sanitize.js
+++ b/packages/core/sanitize.js
@@ -1,0 +1,27 @@
+export function sanitizeNode(node) {
+  // Remove <script> elements and any inline event handlers to mitigate XSS
+  const walker = (el) => {
+    if (el.querySelectorAll) {
+      el.querySelectorAll('script,link[rel="import"],meta,style').forEach((s) => s.remove());
+    }
+    if (el instanceof Element || el instanceof DocumentFragment) {
+      const elements = el instanceof Element ? [el, ...el.querySelectorAll('*')] : [...el.querySelectorAll('*')];
+      for (const elem of elements) {
+        for (const attr of [...elem.attributes]) {
+          if (/^on/i.test(attr.name)) {
+            elem.removeAttribute(attr.name);
+          }
+        }
+      }
+    }
+  };
+  walker(node);
+  return node;
+}
+
+export function sanitizeHTML(html) {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  sanitizeNode(template.content);
+  return template.innerHTML;
+}

--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -1,3 +1,5 @@
+import { sanitizeNode } from './sanitize.js';
+
 class CapsSelect extends HTMLElement {
   static get observedAttributes() {
     return ['disabled', 'multiple', 'name', 'size', 'value', 'aria-label', 'aria-describedby', 'role'];
@@ -77,7 +79,7 @@ class CapsSelect extends HTMLElement {
     select.innerHTML = '';
     for (const node of slot.assignedNodes()) {
       if (node.nodeName === 'OPTION' || node.nodeName === 'OPTGROUP') {
-        select.appendChild(node);
+        select.appendChild(sanitizeNode(node));
       }
     }
     if (this.hasAttribute('value')) {

--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -1,4 +1,5 @@
 import { getLocale, onLocaleChange } from './locale.js';
+import { sanitizeNode } from './sanitize.js';
 
 class CapsTabs extends HTMLElement {
   constructor() {
@@ -65,11 +66,13 @@ class CapsTabs extends HTMLElement {
       const dir = this.getAttribute('dir') || getLocale().dir;
       const isRtl = dir === 'rtl';
       tabs.forEach((tab, i) => {
+        sanitizeNode(tab);
         tab.setAttribute('role', 'tab');
         tab.setAttribute('tabindex', i === 0 ? '0' : '-1');
         tab.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
         const panel = panels[i];
         if (panel) {
+          sanitizeNode(panel);
           if (!panel.id) panel.id = `caps-panel-${i}`;
           tab.setAttribute('aria-controls', panel.id);
         }


### PR DESCRIPTION
## Summary
- export helper to sanitize DOM nodes and HTML strings
- strip inline event handlers from `<caps-select>` options and `<caps-tabs>` slotted content
- document security practices and CSP configuration

## Testing
- `pnpm lint`
- `pnpm test` (fails: 1 failing test)


------
https://chatgpt.com/codex/tasks/task_e_68bb5a8cf7388328891754e5589187c3