### PR TITLE
feat(core): sanitize tenant and theme names

### DIFF
--- a/packages/core/theme-manager.js
+++ b/packages/core/theme-manager.js
@@ -1,4 +1,13 @@
 const varNameRe = /^[a-z0-9-]+$/i;
+const tenantThemeRe = /^[a-z0-9-]+$/i;
+
+function sanitizeName(name) {
+  const sanitized = String(name).replace(/[^a-z0-9-]/gi, '-');
+  if (!tenantThemeRe.test(sanitized)) {
+    throw new Error(`Invalid tenant or theme: ${name}`);
+  }
+  return sanitized;
+}
 
 function sanitize(vars) {
   return Object.entries(vars).reduce((acc, [key, value]) => {
@@ -17,6 +26,7 @@ function sanitize(vars) {
 export class ThemeManager {
   static register(tenant, variables) {
     if (typeof document === 'undefined') return;
+    tenant = sanitizeName(tenant);
     const vars = sanitize(variables);
     const id = `caps-theme-${tenant}`;
     let style = document.getElementById(id);
@@ -33,6 +43,8 @@ export class ThemeManager {
 
   static registerTheme(tenant, theme, variables) {
     if (typeof document === 'undefined') return;
+    tenant = sanitizeName(tenant);
+    theme = sanitizeName(theme);
     const vars = sanitize(variables);
     const id = `caps-theme-${tenant}-${theme}`;
     let style = document.getElementById(id);
@@ -58,11 +70,14 @@ export class ThemeManager {
 
   static apply(tenant, element = document.documentElement) {
     if (typeof document === 'undefined') return;
+    tenant = sanitizeName(tenant);
     element.setAttribute('data-tenant', tenant);
   }
 
   static applyTheme(tenant, theme, element = document.documentElement) {
     if (typeof document === 'undefined') return;
+    tenant = sanitizeName(tenant);
+    theme = sanitizeName(theme);
     element.setAttribute('data-tenant', tenant);
     element.setAttribute('data-theme', theme);
   }

--- a/tests/theme-manager.test.js
+++ b/tests/theme-manager.test.js
@@ -60,3 +60,34 @@ test('ThemeManager loads and switches tenant themes at runtime', async () => {
   assert.ok(style.includes('--caps-btn-bg: black'));
 });
 
+test('ThemeManager sanitizes invalid tenant names', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const { ThemeManager } = await import('../packages/core/theme-manager.js');
+
+  ThemeManager.register('acme!', { 'caps-btn-bg': 'green' });
+  const el = document.createElement('div');
+  ThemeManager.apply('acme!', el);
+  assert.equal(el.getAttribute('data-tenant'), 'acme-');
+  const style = document.getElementById('caps-theme-acme-').textContent;
+  assert.ok(style.includes('[data-tenant="acme-"]'));
+});
+
+test('ThemeManager sanitizes invalid tenant and theme names', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const { ThemeManager } = await import('../packages/core/theme-manager.js');
+
+  ThemeManager.registerTheme('foo bar', 'dark*mode', { 'caps-btn-bg': 'purple' });
+  const el = document.createElement('div');
+  ThemeManager.applyTheme('foo bar', 'dark*mode', el);
+  assert.equal(el.getAttribute('data-tenant'), 'foo-bar');
+  assert.equal(el.getAttribute('data-theme'), 'dark-mode');
+  const style = document.getElementById('caps-theme-foo-bar-dark-mode').textContent;
+  assert.ok(style.includes('[data-tenant="foo-bar"][data-theme="dark-mode"]'));
+});
+


### PR DESCRIPTION
## Summary
- validate and sanitize tenant/theme names before usage
- apply sanitization in register/registerTheme and apply/applyTheme
- add tests for valid and invalid tenant and theme names

## Testing
- `node --test tests/theme-manager.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb6103e0ac832894638da4e564642b