### PR TITLE
feat(core): support locale functions without DOM

### DIFF
--- a/packages/core/locale.js
+++ b/packages/core/locale.js
@@ -1,7 +1,10 @@
-let current = {
-  lang: document.documentElement.lang || 'en',
-  dir: document.documentElement.dir || 'ltr'
-};
+let current =
+  typeof document !== 'undefined'
+    ? {
+        lang: document.documentElement.lang || 'en',
+        dir: document.documentElement.dir || 'ltr',
+      }
+    : { lang: 'en', dir: 'ltr' };
 
 const EVENT = 'capsule:localechange';
 
@@ -11,20 +14,29 @@ export function getLocale() {
 
 export function setLocale({ lang, dir } = {}) {
   if (lang) {
-    document.documentElement.lang = lang;
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = lang;
+    }
     current.lang = lang;
   }
   if (dir) {
-    document.documentElement.dir = dir;
+    if (typeof document !== 'undefined') {
+      document.documentElement.dir = dir;
+    }
     current.dir = dir;
   }
-  window.dispatchEvent(new CustomEvent(EVENT, { detail: { ...current } }));
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(EVENT, { detail: { ...current } }));
+  }
 }
 
 export function onLocaleChange(callback) {
   const handler = (e) => callback(e.detail);
-  window.addEventListener(EVENT, handler);
-  return () => window.removeEventListener(EVENT, handler);
+  if (typeof window !== 'undefined') {
+    window.addEventListener(EVENT, handler);
+    return () => window.removeEventListener(EVENT, handler);
+  }
+  return () => {};
 }
 
 const numberFormatCache = new Map();

--- a/tests/locale-non-dom.test.js
+++ b/tests/locale-non-dom.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('locale functions operate without DOM', async () => {
+  delete global.window;
+  delete global.document;
+  delete global.CustomEvent;
+
+  const locale = await import('../packages/core/locale.js');
+
+  assert.deepEqual(locale.getLocale(), { lang: 'en', dir: 'ltr' });
+
+  assert.doesNotThrow(() => {
+    locale.setLocale({ lang: 'fr', dir: 'rtl' });
+  });
+
+  assert.deepEqual(locale.getLocale(), { lang: 'fr', dir: 'rtl' });
+
+  assert.doesNotThrow(() => {
+    const off = locale.onLocaleChange(() => {});
+    off();
+  });
+});
+


### PR DESCRIPTION
## Summary
- avoid ReferenceError when document/window missing in locale helper
- add tests for locale behavior in non-DOM environments

## Testing
- `node --test tests/locale-non-dom.test.js` *(fails: Error parsing /workspace/Capsule-UI/package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bb60fd3f808328a1bbce3766acde34