### PR TITLE
Sync value property with attribute in input and select

### DIFF
--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -100,8 +100,11 @@ class CapsInput extends HTMLElement {
   }
 
   set value(v) {
-    const input = this.shadowRoot.querySelector('input');
-    if (input) input.value = v;
+    if (v) {
+      this.setAttribute('value', v);
+    } else {
+      this.removeAttribute('value');
+    }
   }
 }
 

--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -102,8 +102,11 @@ class CapsSelect extends HTMLElement {
   }
 
   set value(v) {
-    const select = this.shadowRoot.querySelector('select');
-    if (select) select.value = v;
+    if (v) {
+      this.setAttribute('value', v);
+    } else {
+      this.removeAttribute('value');
+    }
   }
 
   focus() {

--- a/tests/input-component.test.js
+++ b/tests/input-component.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+test('caps-input reflects value between property and attribute', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.CustomEvent = dom.window.CustomEvent;
+
+  await import('../packages/core/input.js');
+
+  const el = document.createElement('caps-input');
+  document.body.appendChild(el);
+
+  el.value = 'hello';
+  assert.equal(el.getAttribute('value'), 'hello');
+  assert.equal(el.shadowRoot.querySelector('input').value, 'hello');
+
+  el.setAttribute('value', 'world');
+  assert.equal(el.value, 'world');
+  assert.equal(el.shadowRoot.querySelector('input').value, 'world');
+
+  el.value = '';
+  assert.equal(el.hasAttribute('value'), false);
+  assert.equal(el.shadowRoot.querySelector('input').value, '');
+});

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -19,6 +19,14 @@ test('caps-select reflects value and disabled', async () => {
   assert.equal(el.value, 'b');
   assert.equal(el.shadowRoot.querySelector('select').value, 'b');
 
+  el.value = 'a';
+  assert.equal(el.getAttribute('value'), 'a');
+  assert.equal(el.shadowRoot.querySelector('select').value, 'a');
+
+  el.value = '';
+  assert.equal(el.hasAttribute('value'), false);
+  assert.equal(el.shadowRoot.querySelector('select').value, '');
+
   el.disabled = true;
   assert.equal(el.shadowRoot.querySelector('select').disabled, true);
 });


### PR DESCRIPTION
## Summary
- ensure `value` setter updates the `value` attribute for `caps-input` and `caps-select`
- rely on `attributeChangedCallback` to sync shadow DOM
- add tests covering property/attribute reflection

## Testing
- `pnpm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6108376083289d5f6243b1711689