### PR TITLE
feat(eslint-plugin): skip rule when tokens missing

### DIFF
--- a/packages/eslint-plugin-capsule/index.js
+++ b/packages/eslint-plugin-capsule/index.js
@@ -27,7 +27,10 @@ function loadTokens() {
     const tokenPath = path.resolve(__dirname, '../../tokens/source/tokens.json');
     const data = JSON.parse(fs.readFileSync(tokenPath, 'utf8'));
     return flattenTokens(data);
-  } catch {
+  } catch (err) {
+    console.warn(
+      "eslint-plugin-capsule: unable to load design tokens; 'no-unknown-token' rule disabled"
+    );
     return [];
   }
 }
@@ -45,6 +48,7 @@ module.exports = {
         schema: []
       },
       create(context) {
+        if (tokenNames.length === 0) return {};
         return {
           JSXAttribute(node) {
             if (!node.name || node.name.name !== 'theme') return;

--- a/tests/no-unknown-token.test.js
+++ b/tests/no-unknown-token.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFile } = require('node:child_process');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+
+test('no-unknown-token rule does nothing when tokens are missing', async () => {
+  const code = `
+    const fs = require('fs');
+    const path = require('path');
+    const tokenPath = path.resolve(process.cwd(), 'tokens/source/tokens.json');
+    const read = fs.readFileSync;
+    fs.readFileSync = (p, ...args) => {
+      if (p === tokenPath) throw new Error('ENOENT');
+      return read(p, ...args);
+    };
+    const plugin = require('./packages/eslint-plugin-capsule');
+    const { Linter } = require('eslint');
+    const linter = new Linter();
+    linter.defineRule('no-unknown-token', plugin.rules['no-unknown-token']);
+    const messages = linter.verify("<div theme='foo'></div>", {
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true }
+      },
+      rules: { 'no-unknown-token': 'error' }
+    });
+    console.log(JSON.stringify(messages));
+  `;
+
+  const output = await new Promise((resolve, reject) => {
+    execFile(process.execPath, ['-e', code], { cwd: root }, (err, stdout) => {
+      if (err) reject(err);
+      else resolve(stdout.trim());
+    });
+  });
+
+  const messages = JSON.parse(output);
+  assert.equal(messages.length, 0);
+});


### PR DESCRIPTION
## Summary
- log a warning and disable `no-unknown-token` rule when design tokens can't load
- add regression test ensuring no lint errors are produced when tokens are unavailable

## Testing
- `pnpm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6100c52483288dd7a04b32e3bd19