### PR TITLE
refactor: generate UI component wrappers dynamically

### DIFF
--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -41,10 +41,23 @@ const createComponent = (tag) =>
       }
     }, children);
   });
+const components = [
+  ['caps-button', 'CapsButton'],
+  ['caps-input', 'CapsInput'],
+  ['caps-card', 'CapsCard'],
+  ['caps-tabs', 'CapsTabs'],
+  ['caps-modal', 'CapsModal'],
+  ['caps-select', 'CapsSelect']
+];
 
-export const CapsButton = createComponent('caps-button');
-export const CapsInput = createComponent('caps-input');
-export const CapsCard = createComponent('caps-card');
-export const CapsTabs = createComponent('caps-tabs');
-export const CapsModal = createComponent('caps-modal');
-export const CapsSelect = createComponent('caps-select');
+export const {
+  CapsButton,
+  CapsInput,
+  CapsCard,
+  CapsTabs,
+  CapsModal,
+  CapsSelect
+} = components.reduce((acc, [tag, name]) => {
+  acc[name] = createComponent(tag);
+  return acc;
+}, {});

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -8,10 +8,23 @@ const createComponent = (tag, name) =>
       return () => h(tag, { ...attrs, ...props }, slots.default ? slots.default() : undefined);
     }
   });
+const components = [
+  ['caps-button', 'CapsButton'],
+  ['caps-input', 'CapsInput'],
+  ['caps-card', 'CapsCard'],
+  ['caps-tabs', 'CapsTabs'],
+  ['caps-modal', 'CapsModal'],
+  ['caps-select', 'CapsSelect']
+];
 
-export const CapsButton = createComponent('caps-button', 'CapsButton');
-export const CapsInput = createComponent('caps-input', 'CapsInput');
-export const CapsCard = createComponent('caps-card', 'CapsCard');
-export const CapsTabs = createComponent('caps-tabs', 'CapsTabs');
-export const CapsModal = createComponent('caps-modal', 'CapsModal');
-export const CapsSelect = createComponent('caps-select', 'CapsSelect');
+export const {
+  CapsButton,
+  CapsInput,
+  CapsCard,
+  CapsTabs,
+  CapsModal,
+  CapsSelect
+} = components.reduce((acc, [tag, name]) => {
+  acc[name] = createComponent(tag, name);
+  return acc;
+}, {});


### PR DESCRIPTION
## Summary
- consolidate React and Vue component wrappers into declarative maps
- dynamically export framework wrappers from component maps

## Testing
- `pnpm test` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb61c9e7448328afadefaeb1cfa452