### PR TITLE
feat: centralize locale direction handling with mixin

### DIFF
--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -1,7 +1,7 @@
-import { getLocale, onLocaleChange } from './locale.js';
+import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
-class CapsButton extends HTMLElement {
+class CapsButton extends withLocaleDir(HTMLElement) {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -62,19 +62,6 @@ class CapsButton extends HTMLElement {
       if (value !== null) btn.setAttribute(name, value);
       else btn.removeAttribute(name);
     }
-  }
-
-  connectedCallback() {
-    if (!this.hasAttribute('dir')) {
-      this.setAttribute('dir', getLocale().dir);
-      this._unsub = onLocaleChange((loc) => {
-        if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
-      });
-    }
-  }
-
-  disconnectedCallback() {
-    this._unsub?.();
   }
 
   focus() {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -5,6 +5,7 @@ export { CapsCard } from './card.js';
 export { CapsTabs } from './tabs.js';
 export { CapsModal } from './modal.js';
 export { CapsSelect } from './select.js';
+export { withLocaleDir } from './withLocaleDir.js';
 export { getLocale, setLocale, onLocaleChange, formatNumber, formatDate, setDirection } from './locale.js';
 export { ThemeManager } from './theme-manager.js';
 export { setTheme, getTheme, onThemeChange } from './theme.js';

--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -1,7 +1,7 @@
-import { getLocale, onLocaleChange } from './locale.js';
+import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
-class CapsInput extends HTMLElement {
+class CapsInput extends withLocaleDir(HTMLElement) {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -67,19 +67,6 @@ class CapsInput extends HTMLElement {
       if (value !== null) input.setAttribute(name, value);
       else input.removeAttribute(name);
     }
-  }
-
-  connectedCallback() {
-    if (!this.hasAttribute('dir')) {
-      this.setAttribute('dir', getLocale().dir);
-      this._unsub = onLocaleChange((loc) => {
-        if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
-      });
-    }
-  }
-
-  disconnectedCallback() {
-    this._unsub?.();
   }
 
   focus() {

--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -1,7 +1,7 @@
-import { getLocale, onLocaleChange } from './locale.js';
+import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
-class CapsModal extends HTMLElement {
+class CapsModal extends withLocaleDir(HTMLElement) {
   static get observedAttributes() { return ['open', 'aria-label', 'aria-labelledby']; }
 
   constructor() {
@@ -62,18 +62,13 @@ class CapsModal extends HTMLElement {
   }
 
   connectedCallback() {
+    super.connectedCallback();
     const backdrop = this.shadowRoot.querySelector('.backdrop');
     backdrop?.addEventListener('click', () => this.removeAttribute('open'));
-    if (!this.hasAttribute('dir')) {
-      this.setAttribute('dir', getLocale().dir);
-      this._unsub = onLocaleChange((loc) => {
-        if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
-      });
-    }
   }
 
   disconnectedCallback() {
-    this._unsub?.();
+    super.disconnectedCallback();
     document.removeEventListener('keydown', this._onKeyDown);
   }
 

--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -1,8 +1,8 @@
-import { getLocale, onLocaleChange } from './locale.js';
+import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 import { sanitizeNode } from './sanitize.js';
 
-class CapsTabs extends HTMLElement {
+class CapsTabs extends withLocaleDir(HTMLElement) {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -57,6 +57,7 @@ class CapsTabs extends HTMLElement {
   }
 
   connectedCallback() {
+    super.connectedCallback();
     const tabSlot = this.shadowRoot.querySelector('slot[name="tab"]');
     const panelSlot = this.shadowRoot.querySelector('slot[name="panel"]');
     const handlers = new WeakMap();
@@ -64,8 +65,7 @@ class CapsTabs extends HTMLElement {
     const assign = () => {
       const tabs = tabSlot.assignedElements();
       const panels = panelSlot.assignedElements();
-      const dir = this.getAttribute('dir') || getLocale().dir;
-      const isRtl = dir === 'rtl';
+      const isRtl = this.getAttribute('dir') === 'rtl';
       tabs.forEach((tab, i) => {
         sanitizeNode(tab);
         tab.setAttribute('role', 'tab');
@@ -118,17 +118,11 @@ class CapsTabs extends HTMLElement {
     tabSlot.addEventListener('slotchange', assign);
     panelSlot.addEventListener('slotchange', assign);
     assign();
-    if (!this.hasAttribute('dir')) {
-      this.setAttribute('dir', getLocale().dir);
-      this._unsub = onLocaleChange((loc) => {
-        if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
-        assign();
-      });
-    }
+    this._assign = assign;
   }
 
-  disconnectedCallback() {
-    this._unsub?.();
+  localeDirChanged() {
+    this._assign?.();
   }
 }
 

--- a/packages/core/withLocaleDir.js
+++ b/packages/core/withLocaleDir.js
@@ -1,0 +1,22 @@
+import { getLocale, onLocaleChange } from './locale.js';
+
+export function withLocaleDir(Base = HTMLElement) {
+  return class extends Base {
+    connectedCallback() {
+      if (super.connectedCallback) super.connectedCallback();
+      if (!this.hasAttribute('dir')) {
+        this.setAttribute('dir', getLocale().dir);
+        this._unsubLocale = onLocaleChange((loc) => {
+          if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
+          this.localeDirChanged?.(loc);
+        });
+      }
+    }
+
+    disconnectedCallback() {
+      this._unsubLocale?.();
+      this._unsubLocale = undefined;
+      if (super.disconnectedCallback) super.disconnectedCallback();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add `withLocaleDir` utility to manage `dir` and locale change subscriptions
- apply `withLocaleDir` to button, input, modal and tabs components
- export `withLocaleDir` from core index and remove duplicated hooks

## Testing
- `pnpm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb61ca959483288aabc8822546a3ff