### PR TITLE
chore: share css modules

### DIFF
--- a/packages/css/index.d.ts
+++ b/packages/css/index.d.ts
@@ -1,0 +1,6 @@
+export const button: { readonly button: string };
+export const input: { readonly input: string };
+export const card: { readonly card: string };
+export const tabs: { readonly tabs: string };
+export const modal: { readonly modal: string };
+export const select: { readonly select: string };

--- a/packages/css/index.js
+++ b/packages/css/index.js
@@ -1,0 +1,8 @@
+import button from '@capsule-ui/core/button.module.css';
+import input from '@capsule-ui/core/input.module.css';
+import card from '@capsule-ui/core/card.module.css';
+import tabs from '@capsule-ui/core/tabs.module.css';
+import modal from '@capsule-ui/core/modal.module.css';
+import select from '@capsule-ui/core/select.module.css';
+
+export { button, input, card, tabs, modal, select };

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@capsule-ui/css",
+  "version": "0.0.1-preview",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "types": "./index.d.ts"
+    }
+  },
+  "dependencies": {
+    "@capsule-ui/core": "workspace:*"
+  }
+}

--- a/packages/react/css/index.d.ts
+++ b/packages/react/css/index.d.ts
@@ -1,6 +1,1 @@
-export const button: { readonly button: string };
-export const input: { readonly input: string };
-export const card: { readonly card: string };
-export const tabs: { readonly tabs: string };
-export const modal: { readonly modal: string };
-export const select: { readonly select: string };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/react/css/index.js
+++ b/packages/react/css/index.js
@@ -1,8 +1,1 @@
-import button from '@capsule-ui/core/button.module.css';
-import input from '@capsule-ui/core/input.module.css';
-import card from '@capsule-ui/core/card.module.css';
-import tabs from '@capsule-ui/core/tabs.module.css';
-import modal from '@capsule-ui/core/modal.module.css';
-import select from '@capsule-ui/core/select.module.css';
-
-export { button, input, card, tabs, modal, select };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,13 +4,18 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" },
-    "./css": { "import": "./css/index.js" }
+    ".": {
+      "import": "./index.js"
+    },
+    "./css": {
+      "import": "./css/index.js"
+    }
   },
   "peerDependencies": {
     "react": "^18.0.0"
   },
   "dependencies": {
-    "@capsule-ui/core": "workspace:*"
+    "@capsule-ui/core": "workspace:*",
+    "@capsule-ui/css": "workspace:*"
   }
 }

--- a/packages/svelte/css/index.d.ts
+++ b/packages/svelte/css/index.d.ts
@@ -1,6 +1,1 @@
-export const button: { readonly button: string };
-export const input: { readonly input: string };
-export const card: { readonly card: string };
-export const tabs: { readonly tabs: string };
-export const modal: { readonly modal: string };
-export const select: { readonly select: string };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/svelte/css/index.js
+++ b/packages/svelte/css/index.js
@@ -1,8 +1,1 @@
-import button from '@capsule-ui/core/button.module.css';
-import input from '@capsule-ui/core/input.module.css';
-import card from '@capsule-ui/core/card.module.css';
-import tabs from '@capsule-ui/core/tabs.module.css';
-import modal from '@capsule-ui/core/modal.module.css';
-import select from '@capsule-ui/core/select.module.css';
-
-export { button, input, card, tabs, modal, select };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -4,13 +4,18 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" },
-    "./css": { "import": "./css/index.js" }
+    ".": {
+      "import": "./index.js"
+    },
+    "./css": {
+      "import": "./css/index.js"
+    }
   },
   "peerDependencies": {
     "svelte": "^4.0.0"
   },
   "dependencies": {
-    "@capsule-ui/core": "workspace:*"
+    "@capsule-ui/core": "workspace:*",
+    "@capsule-ui/css": "workspace:*"
   }
 }

--- a/packages/vue/css/index.d.ts
+++ b/packages/vue/css/index.d.ts
@@ -1,6 +1,1 @@
-export const button: { readonly button: string };
-export const input: { readonly input: string };
-export const card: { readonly card: string };
-export const tabs: { readonly tabs: string };
-export const modal: { readonly modal: string };
-export const select: { readonly select: string };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/vue/css/index.js
+++ b/packages/vue/css/index.js
@@ -1,8 +1,1 @@
-import button from '@capsule-ui/core/button.module.css';
-import input from '@capsule-ui/core/input.module.css';
-import card from '@capsule-ui/core/card.module.css';
-import tabs from '@capsule-ui/core/tabs.module.css';
-import modal from '@capsule-ui/core/modal.module.css';
-import select from '@capsule-ui/core/select.module.css';
-
-export { button, input, card, tabs, modal, select };
+export { button, input, card, tabs, modal, select } from '@capsule-ui/css';

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -4,13 +4,18 @@
   "type": "module",
   "main": "index.js",
   "exports": {
-    ".": { "import": "./index.js" },
-    "./css": { "import": "./css/index.js" }
+    ".": {
+      "import": "./index.js"
+    },
+    "./css": {
+      "import": "./css/index.js"
+    }
   },
   "peerDependencies": {
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@capsule-ui/core": "workspace:*"
+    "@capsule-ui/core": "workspace:*",
+    "@capsule-ui/css": "workspace:*"
   }
 }


### PR DESCRIPTION
## Summary
- add `@capsule-ui/css` package to centralize core CSS modules
- re-export css from `@capsule-ui/css` in React/Vue/Svelte packages
- depend on shared css package so consumers resolve styles consistently

## Testing
- `pnpm lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb61c9aba48328889cec222d3d4780