### PR TITLE
Manage analytics timer lifecycle

### DIFF
--- a/packages/core/analytics.test.js
+++ b/packages/core/analytics.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('enableAnalytics sets up and disableAnalytics tears down interval and listener', async () => {
+  let intervalSet = 0;
+  let intervalCleared = false;
+  const originalSetInterval = global.setInterval;
+  const originalClearInterval = global.clearInterval;
+
+  global.setInterval = (fn, time) => {
+    intervalSet = time;
+    return 123;
+  };
+  global.clearInterval = (id) => {
+    if (id === 123) intervalCleared = true;
+  };
+
+  let addCalled = false;
+  let removeCalled = false;
+  const windowMock = {
+    addEventListener: (ev, handler) => {
+      if (ev === 'beforeunload') {
+        addCalled = true;
+        windowMock.handler = handler;
+      }
+    },
+    removeEventListener: (ev, handler) => {
+      if (ev === 'beforeunload' && handler === windowMock.handler) {
+        removeCalled = true;
+      }
+    }
+  };
+  global.window = windowMock;
+
+  const { enableAnalytics, disableAnalytics } = await import('./analytics.js');
+
+  enableAnalytics();
+  assert.equal(addCalled, true);
+  assert.equal(intervalSet, 60000);
+
+  disableAnalytics();
+  assert.equal(removeCalled, true);
+  assert.equal(intervalCleared, true);
+
+  global.setInterval = originalSetInterval;
+  global.clearInterval = originalClearInterval;
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- track and control analytics setInterval and beforeunload listener
- add test confirming interval and listener teardown

## Testing
- `npx eslint@8 packages/core/analytics.js packages/core/analytics.test.js`
- `node --test packages/core/analytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb61cb5a30832895020a3b8df27f64