### PR TITLE
feat(cli): enrich scaffolding docs

### DIFF
--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -236,7 +236,7 @@ export async function scaffoldComponent(rawName, baseDir = 'packages/components'
     const styleSrc = `export interface ${name}StyleProps {\n  // TODO: define style props\n}\n\nexport const create${name}Styles = (_: ${name}StyleProps) => {\n  // TODO: implement Style API\n};\n`;
     const indexSrc = `export * from './${name}';\nexport * from './style';\n`;
     const testSrc = `import test from 'node:test';\nimport assert from 'node:assert/strict';\n\ntest('${name}', () => {\n  assert.equal(1, 1);\n});\n`;
-    const docSrc = `# ${name}\n\nDocumentation stub for ${name}.\n`;
+    const docSrc = `# ${name}\n\nShort description of ${name}.\n\n## Usage\n\n\`\`\`html\n<${name} />\n\`\`\`\n\n## Props\n\n<!-- TODO: document component props -->\n\n## Slots\n\n<!-- TODO: document component slots -->\n`;
     const templatePath = join(adrDir, '000-style-contract-template.md');
     let adrSrc = '';
     try {
@@ -245,8 +245,14 @@ export async function scaffoldComponent(rawName, baseDir = 'packages/components'
         /^# ADR 000: Style Contract Template/,
         `# ADR ${adrNumber}: ${name} Style Contract`
       );
+      if (!adrSrc.includes('## Rationale')) {
+        adrSrc = adrSrc.replace(
+          '## Decision',
+          '## Rationale\nDiscuss alternative approaches and why this solution was chosen.\n\n## Decision'
+        );
+      }
     } catch {
-      adrSrc = `# ADR ${adrNumber}: ${name} Style Contract\n`;
+      adrSrc = `# ADR ${adrNumber}: ${name} Style Contract\n\n## Status\nDraft\n\n## Context\nExplain why this style decision is needed and what problem it addresses.\n\n## Rationale\nDiscuss alternative approaches and why this solution was chosen.\n\n## Decision\nDetail the style contract including scope by default, token usage, layer ordering, and variant strategy.\n\n## Consequences\nNote any trade-offs, follow-up work, or implications of this decision.\n`;
     }
 
     await mkdir(docsDir, { recursive: true });

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -186,6 +186,14 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       path.join(tempDir, 'packages', 'components', 'index.ts'),
       'utf8'
     );
+    const doc = await readFile(
+      path.join(tempDir, 'docs', 'components', 'example-component.md'),
+      'utf8'
+    );
+    const adr = await readFile(
+      path.join(tempDir, 'docs', 'adr', '001-example-component.md'),
+      'utf8'
+    );
 
     assert.equal(
       component,
@@ -210,6 +218,14 @@ test('scaffoldComponent returns true and generates expected files', async () => 
     assert.equal(
       rootIndex,
       `export * from './ExampleComponent/ExampleComponent';\n`
+    );
+    assert.equal(
+      doc,
+      `# ExampleComponent\n\nShort description of ExampleComponent.\n\n## Usage\n\n\`\`\`html\n<ExampleComponent />\n\`\`\`\n\n## Props\n\n<!-- TODO: document component props -->\n\n## Slots\n\n<!-- TODO: document component slots -->\n`
+    );
+    assert.equal(
+      adr,
+      `# ADR 001: ExampleComponent Style Contract\n\n## Status\nDraft\n\n## Context\nExplain why this style decision is needed and what problem it addresses.\n\n## Rationale\nDiscuss alternative approaches and why this solution was chosen.\n\n## Decision\nDetail the style contract including scope by default, token usage, layer ordering, and variant strategy.\n\n## Consequences\nNote any trade-offs, follow-up work, or implications of this decision.\n`
     );
   } finally {
     process.chdir(originalCwd);


### PR DESCRIPTION
## Summary
- scaffolded component docs now include description, usage example, and props/slots placeholders
- ADR generation prefills rationale and decision sections with guidance
- tests verify new documentation and ADR output

## Testing
- `node --test tests/scaffold-component.test.js` *(fails: SyntaxError: Error parsing /workspace/Capsule-UI/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb62715d288328980f2dc276d4032e