### PR TITLE
feat: improve component scaffold templates

### DIFF
--- a/scripts/new-component.mjs
+++ b/scripts/new-component.mjs
@@ -24,12 +24,22 @@ if (fs.existsSync(jsPath) || fs.existsSync(cssPath)) {
 
 fs.writeFileSync(
   jsPath,
-  `import styles from './${kebab}.module.css';\n\nexport function ${name}() {\n  // TODO: implement ${name}\n}\n`
+  `import styles from './${kebab}.module.css';
+
+export function ${name}() {
+  return \`<div class=\"\${styles['${kebab}']}\"></div>\`;
+}
+`
 );
 
 fs.writeFileSync(
   cssPath,
-  `@layer components;\n\n.${kebab} {\n  /* TODO: component styles */\n}\n`
+  `@layer components;
+
+.${kebab} {
+  display: block;
+}
+`
 );
 
 const adrDir = path.join('docs', 'adr');


### PR DESCRIPTION
## Summary
- scaffolded JS template now returns a minimal component element
- include default `display: block` rule in CSS template

## Testing
- `node scripts/new-component.mjs TestComponent`
- `node --loader ./css-loader.mjs -e "import('./packages/core/test-component.js').then(m=>console.log(m.TestComponent()))"`
- `pnpm test` (fails: Invalid package.json)
- `node examples/booking-widget.js` (fails: Expected ',' or '}' after property value in JSON)


------
https://chatgpt.com/codex/tasks/task_e_68bb626e681483288ac9c588a3f610bc