### PR TITLE
feat(core): expose style recipes for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ Example:
 
 ```js
 import { buttonRecipe } from '@capsule-ui/core/button.recipe';
+import { cardRecipe } from '@capsule-ui/core/card.recipe';
 
-const className = buttonRecipe({ size: 'lg', variant: 'secondary' });
+const btnClass = buttonRecipe({ size: 'lg', variant: 'secondary' });
+const cardClass = cardRecipe({ variant: 'outline' });
 ```
+
+Each core component ships with a matching recipe (e.g., `inputRecipe`, `selectRecipe`, `tabsRecipe`, `modalRecipe`) for CSS Module workflows.
 
 ### 5) Container‑query first
 Components adapt to their container:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,13 +31,13 @@ A living plan toward v1.0. We prioritize stability, clear contracts, and great D
 
 ## Milestone 2 — Component Recipes (Variants)
 - Adopt CVA/stylex/Panda/UnoCSS (compiled) for variant recipes.
-- Initial integration with `class-variance-authority` for button.
+- Use `class-variance-authority` recipes for core components.
 - Pattern: props → classes; zero runtime CSS generation.
 - Lint rule to forbid ad‑hoc class soup in callsites; enforce recipes.
 
 **Exit criteria:** All components expose typed variant APIs with autocomplete.
 
-**Status:** In progress — CVA integrated with a button recipe and lint rule to ban ad-hoc classes. Target: December 2025.
+**Status:** In progress — CVA recipes exist for core components and lint rule to ban ad-hoc classes. Target: December 2025.
 
 ---
 

--- a/packages/core/card.module.css
+++ b/packages/core/card.module.css
@@ -10,6 +10,9 @@
 .card:where([data-variant="outline"]) {
   box-shadow: none;
 }
+.variant-outline {
+  box-shadow: none;
+}
 @container (min-width: 600px) {
   .card { padding: calc(var(--spacing-lg) * 1.5); }
 }

--- a/packages/core/card.recipe.d.ts
+++ b/packages/core/card.recipe.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+import type { VariantProps } from 'class-variance-authority';
+
+export declare const cardRecipe: (options?: {
+  variant?: 'outline';
+}) => string;
+
+export type CardRecipeProps = VariantProps<typeof cardRecipe>;
+

--- a/packages/core/card.recipe.js
+++ b/packages/core/card.recipe.js
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+import styles from './card.module.css';
+
+export const cardRecipe = cva(styles.card, {
+  variants: {
+    variant: {
+      outline: styles['variant-outline']
+    }
+  }
+});
+
+/**
+ * @typedef {import('class-variance-authority').VariantProps<typeof cardRecipe>} CardRecipeProps
+ */
+

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,10 +1,15 @@
 export { CapsButton } from './button.js';
 export { buttonRecipe } from './button.recipe.js';
 export { CapsInput } from './input.js';
+export { inputRecipe } from './input.recipe.js';
 export { CapsCard } from './card.js';
+export { cardRecipe } from './card.recipe.js';
 export { CapsTabs } from './tabs.js';
+export { tabsRecipe } from './tabs.recipe.js';
 export { CapsModal } from './modal.js';
+export { modalRecipe } from './modal.recipe.js';
 export { CapsSelect } from './select.js';
+export { selectRecipe } from './select.recipe.js';
 export { getLocale, setLocale, onLocaleChange, formatNumber, formatDate, setDirection } from './locale.js';
 export { ThemeManager } from './theme-manager.js';
 export { setTheme, getTheme, onThemeChange } from './theme.js';

--- a/packages/core/input.module.css
+++ b/packages/core/input.module.css
@@ -12,6 +12,9 @@
 .input:where([data-variant="outline"]) {
   background: transparent;
 }
+.variant-outline {
+  background: transparent;
+}
 @container (min-width: 480px) {
   .input { padding: var(--spacing-md) var(--spacing-lg); }
 }

--- a/packages/core/input.recipe.d.ts
+++ b/packages/core/input.recipe.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+import type { VariantProps } from 'class-variance-authority';
+
+export declare const inputRecipe: (options?: {
+  variant?: 'outline';
+}) => string;
+
+export type InputRecipeProps = VariantProps<typeof inputRecipe>;
+

--- a/packages/core/input.recipe.js
+++ b/packages/core/input.recipe.js
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+import styles from './input.module.css';
+
+export const inputRecipe = cva(styles.input, {
+  variants: {
+    variant: {
+      outline: styles['variant-outline']
+    }
+  }
+});
+
+/**
+ * @typedef {import('class-variance-authority').VariantProps<typeof inputRecipe>} InputRecipeProps
+ */
+

--- a/packages/core/modal.module.css
+++ b/packages/core/modal.module.css
@@ -32,7 +32,8 @@
   .backdrop { background: var(--color-overlay); }
   .modal { background: var(--color-background); color: var(--color-text); }
 }
-:where(.container[data-variant="fullscreen"]) .modal {
+:where(.container[data-variant="fullscreen"]) .modal,
+.container.variant-fullscreen .modal {
   inset: 0;
   top: 0;
   left: 0;

--- a/packages/core/modal.recipe.d.ts
+++ b/packages/core/modal.recipe.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+import type { VariantProps } from 'class-variance-authority';
+
+export declare const modalRecipe: (options?: {
+  variant?: 'fullscreen';
+}) => string;
+
+export type ModalRecipeProps = VariantProps<typeof modalRecipe>;
+

--- a/packages/core/modal.recipe.js
+++ b/packages/core/modal.recipe.js
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+import styles from './modal.module.css';
+
+export const modalRecipe = cva(styles.container, {
+  variants: {
+    variant: {
+      fullscreen: styles['variant-fullscreen']
+    }
+  }
+});
+
+/**
+ * @typedef {import('class-variance-authority').VariantProps<typeof modalRecipe>} ModalRecipeProps
+ */
+

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,26 @@
     "./button.recipe": {
       "import": "./button.recipe.js",
       "types": "./button.recipe.d.ts"
+    },
+    "./card.recipe": {
+      "import": "./card.recipe.js",
+      "types": "./card.recipe.d.ts"
+    },
+    "./input.recipe": {
+      "import": "./input.recipe.js",
+      "types": "./input.recipe.d.ts"
+    },
+    "./tabs.recipe": {
+      "import": "./tabs.recipe.js",
+      "types": "./tabs.recipe.d.ts"
+    },
+    "./modal.recipe": {
+      "import": "./modal.recipe.js",
+      "types": "./modal.recipe.d.ts"
+    },
+    "./select.recipe": {
+      "import": "./select.recipe.js",
+      "types": "./select.recipe.d.ts"
     }
   },
   "dependencies": {

--- a/packages/core/select.module.css
+++ b/packages/core/select.module.css
@@ -12,6 +12,9 @@
 .select:where([data-variant="outline"]) {
   background: transparent;
 }
+.variant-outline {
+  background: transparent;
+}
 @container (min-width: 480px) {
   .select { padding: var(--spacing-md) var(--spacing-lg); }
 }

--- a/packages/core/select.recipe.d.ts
+++ b/packages/core/select.recipe.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+import type { VariantProps } from 'class-variance-authority';
+
+export declare const selectRecipe: (options?: {
+  variant?: 'outline';
+}) => string;
+
+export type SelectRecipeProps = VariantProps<typeof selectRecipe>;
+

--- a/packages/core/select.recipe.js
+++ b/packages/core/select.recipe.js
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+import styles from './select.module.css';
+
+export const selectRecipe = cva(styles.select, {
+  variants: {
+    variant: {
+      outline: styles['variant-outline']
+    }
+  }
+});
+
+/**
+ * @typedef {import('class-variance-authority').VariantProps<typeof selectRecipe>} SelectRecipeProps
+ */
+

--- a/packages/core/tabs.module.css
+++ b/packages/core/tabs.module.css
@@ -18,7 +18,8 @@
   outline: 2px solid var(--color-text);
   outline-offset: 2px;
 }
-:where(.tabs[data-variant="pill"]) .tab {
+:where(.tabs[data-variant="pill"]) .tab,
+.tabs.variant-pill .tab {
   border-radius: 999px;
 }
 .tab:where([aria-selected='true']) {

--- a/packages/core/tabs.recipe.d.ts
+++ b/packages/core/tabs.recipe.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable no-unused-vars */
+import type { VariantProps } from 'class-variance-authority';
+
+export declare const tabsRecipe: (options?: {
+  variant?: 'pill';
+}) => string;
+
+export type TabsRecipeProps = VariantProps<typeof tabsRecipe>;
+

--- a/packages/core/tabs.recipe.js
+++ b/packages/core/tabs.recipe.js
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+import styles from './tabs.module.css';
+
+export const tabsRecipe = cva(styles.tabs, {
+  variants: {
+    variant: {
+      pill: styles['variant-pill']
+    }
+  }
+});
+
+/**
+ * @typedef {import('class-variance-authority').VariantProps<typeof tabsRecipe>} TabsRecipeProps
+ */
+

--- a/tests/style-recipes.test.js
+++ b/tests/style-recipes.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+test('core package exports style recipes for each component', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../packages/core/package.json'), 'utf8'));
+  const components = ['button', 'card', 'input', 'tabs', 'modal', 'select'];
+  for (const name of components) {
+    assert.ok(fs.existsSync(path.join(__dirname, `../packages/core/${name}.recipe.js`)), `${name} recipe missing`);
+    assert.ok(pkg.exports[`./${name}.recipe`], `package.json missing export for ${name}`);
+  }
+});
+


### PR DESCRIPTION
## Summary
- add CVA recipes for card, input, tabs, modal, and select
- export new recipes and update package exports and docs
- add test to ensure recipe files are published

## Testing
- `npx tsc stylelint/require-layer.ts --esModuleInterop --module commonjs --target ES2022 --skipLibCheck` *(fails: Cannot find module 'stylelint' or its corresponding type declarations)*
- `node --test` *(fails: SyntaxError: Error parsing package.json)*
- `node scripts/a11y-check.mjs` *(fails: ERR_INVALID_PACKAGE_CONFIG)*
- `node scripts/check-runtime-styles.mjs`
- `npx playwright test` *(fails: needs to install playwright@1.55.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb61cc95888328823a7843cdd79f80