### PR TITLE
ci: ensure pnpm is installed for cached workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint:css
       - run: pnpm run lint:js
@@ -30,10 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:a11y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
       - run: pnpm test


### PR DESCRIPTION
## Summary
- install pnpm before setup-node to use pnpm cache
- apply same fix to release workflow

## Testing
- `pnpm lint` *(fails: Expected ".container.variant-fullscreen .modal" to have a specificity no more than "0,1,0")*
- `pnpm test` *(fails: 2 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6584b8788328a43eb00a5a9c8074