### PR TITLE
feat: enhance migration codemods and docs

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -11,17 +11,16 @@ capsule migrate emotion [paths]
 
 ## Tailwind / utility classes
 
-The Tailwind codemod looks for button elements with utility classes such as
-`className="btn btn-primary"` or `class="btn btn-primary"` in React, Vue and
-Svelte files. These are replaced with `CapsButton` components and a `variant`
-prop when a `btn-*` class is present. Imports for the correct framework
-adapter are injected automatically.
+The Tailwind codemod looks for utility classes such as `btn`, `input`, `card`,
+`tabs`, `modal` and `select` in React, Vue and Svelte files. It also understands
+dynamic `className` expressions (`clsx`, template literals, conditional
+expressions, etc.). Matching elements are replaced with the corresponding
+`Caps*` component and a `variant` prop when a `*-foo` class is present. Imports
+for the correct framework adapter are injected automatically.
 
 **Manual follow‑ups**
 
-- Dynamic class expressions are left untouched and should be migrated by hand.
-- Only simple `btn` patterns are recognised; other utilities require manual
-  conversion.
+- Highly dynamic class constructions may still require manual review.
 
 ## Emotion / styled‑components
 
@@ -35,6 +34,21 @@ styled‑components) and replaces their usages with `CapsButton` from
 - Custom CSS beyond Capsule variants should be reviewed and moved to the
   appropriate Capsule API.
 - Components other than `button` are currently ignored.
+
+## Other CSS‑in‑JS libraries
+
+Projects using libraries such as **styled‑system** can migrate by replacing
+style props with Capsule's style factories or utility props. Map any `variant`
+or spacing props to the equivalent Capsule component props or CSS variables and
+remove library‑specific helpers during the refactor.
+
+## Bootstrap / Material UI
+
+Popular component libraries can be migrated incrementally. Replace Bootstrap's
+`btn`/`form-control` classes or Material UI components like `<Button>` and
+`<TextField>` with their Capsule counterparts (`CapsButton`, `CapsInput`, etc.),
+mapping colour or variant props as needed. Layout utilities should be moved to
+Capsule tokens or components.
 
 Run the codemods incrementally and verify the results. Commit the generated
 changes and complete any manual steps described above.

--- a/packages/capsule-cli/README.md
+++ b/packages/capsule-cli/README.md
@@ -57,7 +57,7 @@ capsule migrate tailwind src/**/*.tsx
 capsule migrate emotion src/
 ```
 
-The Tailwind codemod finds `className` values such as `btn btn-primary` and replaces them with `<CapsButton>` elements using a `variant` prop. The Emotion codemod removes `styled.button` declarations and swaps their usages for `CapsButton` imports.
+The Tailwind codemod recognises utility classes like `btn`, `input`, `card`, `tabs`, `modal` and `select`, even inside dynamic `className` expressions (`clsx`, template literals, etc.). Matched elements are replaced with the corresponding Capsule components and a `variant` prop when a `*-foo` class is present. The Emotion codemod removes `styled.button` declarations and swaps their usages for `CapsButton` imports.
 
 ## Other commands
 

--- a/packages/capsule-cli/codemods/tailwind.js
+++ b/packages/capsule-cli/codemods/tailwind.js
@@ -4,71 +4,220 @@ module.exports = function tailwindToCapsule(fileInfo, api, options) {
   const source = fileInfo.source;
   let didTransform = false;
 
+  const utilMap = {
+    btn: 'CapsButton',
+    input: 'CapsInput',
+    card: 'CapsCard',
+    tabs: 'CapsTabs',
+    modal: 'CapsModal',
+    select: 'CapsSelect'
+  };
+  const utilPrefixes = Object.keys(utilMap);
+
   if (ext === 'vue' || ext === 'svelte') {
-    let pkg;
-    if (ext === 'vue') pkg = '@capsule-ui/vue';
-    else pkg = '@capsule-ui/svelte';
-    let out = source.replace(/<button([^>]*?)class=["']([^"']*?btn[^"']*?)["']([^>]*)>/g, (match, pre, classes, post) => {
-      didTransform = true;
-      const m = classes.match(/btn-([\w-]+)/);
-      const variant = m ? ` variant=\"${m[1]}\"` : '';
-      return `<CapsButton${variant}${pre}${post}>`;
-    }).replace(/<\/button>/g, '</CapsButton>');
-    if (didTransform) {
+    const pkg = ext === 'vue' ? '@capsule-ui/vue' : '@capsule-ui/svelte';
+    let out = source;
+    const used = new Set();
+
+    const vueMap = [
+      { prefix: 'btn', tag: 'button', component: 'CapsButton', selfClosing: false },
+      { prefix: 'input', tag: 'input', component: 'CapsInput', selfClosing: true },
+      { prefix: 'card', tag: 'div', component: 'CapsCard', selfClosing: false },
+      { prefix: 'tabs', tag: 'div', component: 'CapsTabs', selfClosing: false },
+      { prefix: 'modal', tag: 'div', component: 'CapsModal', selfClosing: false },
+      { prefix: 'select', tag: 'select', component: 'CapsSelect', selfClosing: false }
+    ];
+
+    vueMap.forEach(({ prefix, tag, component, selfClosing }) => {
+      if (selfClosing) {
+        const re = new RegExp(
+          `<${tag}([^>]*?)class=["']([^"']*?${prefix}[^"']*?)["']([^>]*)/?>`,
+          'g'
+        );
+        out = out.replace(re, (match, pre, classes, post) => {
+          used.add(component);
+          didTransform = true;
+          const m = classes.match(new RegExp(`${prefix}-([\\w-]+)`));
+          const variant = m ? ` variant=\\"${m[1]}\\"` : '';
+          return `<${component}${variant}${pre}${post} />`;
+        });
+      } else {
+        const re = new RegExp(
+          `<${tag}([^>]*?)class=["']([^"']*?${prefix}[^"']*?)["']([^>]*)>([\\s\\S]*?)</${tag}>`,
+          'g'
+        );
+        out = out.replace(re, (match, pre, classes, post, inner) => {
+          used.add(component);
+          didTransform = true;
+          const m = classes.match(new RegExp(`${prefix}-([\\w-]+)`));
+          const variant = m ? ` variant=\\"${m[1]}\\"` : '';
+          return `<${component}${variant}${pre}${post}>${inner}</${component}>`;
+        });
+      }
+    });
+
+    if (didTransform && used.size) {
+      const imports = Array.from(used).join(', ');
       if (!out.includes(pkg)) {
         if (ext === 'vue') {
-          out = out.replace(/<script[^>]*>/, (m) => `${m}\nimport { CapsButton } from '${pkg}';`);
+          out = out.replace(
+            /<script[^>]*>/,
+            (m) => `${m}\nimport { ${imports} } from '${pkg}';`
+          );
         } else {
-          out = `import { CapsButton } from '${pkg}';\n` + out;
+          out = `import { ${imports} } from '${pkg}';\n` + out;
         }
       }
     }
+
     return out;
   }
 
   const root = j(source);
+  const replacements = new Set();
 
-  root.find(j.JSXElement, { openingElement: { name: { name: 'button' } } }).forEach((path) => {
+  const parseLiteral = (str) => str.split(/\s+/).filter(Boolean);
+
+  const extractClasses = (node, classNames, variantExprs) => {
+    if (!node) return;
+    switch (node.type) {
+      case 'Literal':
+      case 'StringLiteral':
+        classNames.push(...parseLiteral(node.value));
+        break;
+      case 'TemplateLiteral':
+        node.quasis.forEach((q, i) => {
+          const text = q.value.cooked;
+          if (text) classNames.push(...parseLiteral(text));
+          const expr = node.expressions[i];
+          if (expr) {
+            const last = text.split(/\s+/).pop();
+            utilPrefixes.forEach((p) => {
+              if (last && last.endsWith(p + '-')) {
+                variantExprs[p] = expr;
+                classNames.push(p);
+              }
+            });
+            extractClasses(expr, classNames, variantExprs);
+          }
+        });
+        break;
+      case 'BinaryExpression':
+        if (node.operator === '+') {
+          extractClasses(node.left, classNames, variantExprs);
+          extractClasses(node.right, classNames, variantExprs);
+        }
+        break;
+      case 'ConditionalExpression':
+        extractClasses(node.consequent, classNames, variantExprs);
+        extractClasses(node.alternate, classNames, variantExprs);
+        break;
+      case 'LogicalExpression':
+        extractClasses(node.left, classNames, variantExprs);
+        extractClasses(node.right, classNames, variantExprs);
+        break;
+      case 'ArrayExpression':
+        node.elements.forEach((el) => extractClasses(el, classNames, variantExprs));
+        break;
+      case 'ObjectExpression':
+        node.properties.forEach((prop) => {
+          if (prop.type === 'Property') {
+            const key = prop.key;
+            if (key.type === 'Literal' || key.type === 'StringLiteral') {
+              classNames.push(...parseLiteral(key.value));
+            } else if (key.type === 'TemplateLiteral') {
+              extractClasses(key, classNames, variantExprs);
+            }
+            extractClasses(prop.value, classNames, variantExprs);
+          }
+        });
+        break;
+      case 'CallExpression':
+        if (
+          node.callee.type === 'Identifier' &&
+          ['clsx', 'classnames', 'cx'].includes(node.callee.name)
+        ) {
+          node.arguments.forEach((arg) => extractClasses(arg, classNames, variantExprs));
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  root.find(j.JSXElement).forEach((path) => {
     const attrs = path.node.openingElement.attributes;
     const classAttr = attrs.find((a) => a.name && a.name.name === 'className');
     if (!classAttr) return;
-    let classValue = null;
-    if (classAttr.value && classAttr.value.type === 'Literal') classValue = classAttr.value.value;
-    else if (
-      classAttr.value &&
-      classAttr.value.type === 'StringLiteral'
-    )
-      classValue = classAttr.value.value;
-    else if (
-      classAttr.value &&
-      classAttr.value.type === 'JSXExpressionContainer' &&
-      classAttr.value.expression.type === 'StringLiteral'
-    )
-      classValue = classAttr.value.expression.value;
-    if (!classValue || !classValue.includes('btn')) return;
-    didTransform = true;
-    const m = classValue.match(/btn-([\w-]+)/);
-    if (m) {
-      attrs.push(j.jsxAttribute(j.jsxIdentifier('variant'), j.stringLiteral(m[1])));
+
+    const classNames = [];
+    const variantExprs = {};
+
+    if (classAttr.value.type === 'Literal') {
+      classNames.push(...parseLiteral(classAttr.value.value));
+    } else if (classAttr.value.type === 'StringLiteral') {
+      classNames.push(...parseLiteral(classAttr.value.value));
+    } else if (classAttr.value.type === 'JSXExpressionContainer') {
+      extractClasses(classAttr.value.expression, classNames, variantExprs);
     }
-    path.node.openingElement.name.name = 'CapsButton';
-    if (path.node.closingElement) path.node.closingElement.name.name = 'CapsButton';
-    path.node.openingElement.attributes = attrs.filter((a) => !(a.name && a.name.name === 'className'));
+
+    let info = null;
+    for (const prefix of utilPrefixes) {
+      const component = utilMap[prefix];
+      const variantExpr = variantExprs[prefix];
+      const cn = classNames.find((c) => c === prefix || c.startsWith(prefix + '-'));
+      if (cn || variantExpr) {
+        let variant = null;
+        if (!variantExpr && cn && cn.startsWith(prefix + '-')) {
+          variant = cn.slice(prefix.length + 1);
+        }
+        info = { component, variant, variantExpr };
+        break;
+      }
+    }
+
+    if (!info) return;
+    didTransform = true;
+    replacements.add(info.component);
+
+    if (info.variantExpr) {
+      attrs.push(
+        j.jsxAttribute(
+          j.jsxIdentifier('variant'),
+          j.jsxExpressionContainer(info.variantExpr)
+        )
+      );
+    } else if (info.variant) {
+      attrs.push(
+        j.jsxAttribute(j.jsxIdentifier('variant'), j.stringLiteral(info.variant))
+      );
+    }
+
+    path.node.openingElement.name.name = info.component;
+    if (path.node.closingElement) path.node.closingElement.name.name = info.component;
+    path.node.openingElement.attributes = attrs.filter(
+      (a) => !(a.name && a.name.name === 'className')
+    );
   });
 
   if (didTransform) {
-    const importDecl = j.importDeclaration(
-      [j.importSpecifier(j.identifier('CapsButton'))],
-      j.stringLiteral('@capsule-ui/react')
+    const existing = root.find(j.ImportDeclaration, {
+      source: { value: '@capsule-ui/react' }
+    });
+    const specs = Array.from(replacements).map((c) =>
+      j.importSpecifier(j.identifier(c))
     );
-    const existing = root.find(j.ImportDeclaration, { source: { value: '@capsule-ui/react' } });
     if (existing.size()) {
-      const specs = existing.get(0).node.specifiers;
-      if (!specs.some((s) => s.imported && s.imported.name === 'CapsButton')) {
-        specs.push(j.importSpecifier(j.identifier('CapsButton')));
-      }
+      const importSpecs = existing.get(0).node.specifiers;
+      specs.forEach((s) => {
+        if (!importSpecs.some((i) => i.imported && i.imported.name === s.imported.name)) {
+          importSpecs.push(s);
+        }
+      });
     } else {
-      root.get().node.program.body.unshift(importDecl);
+      root.get().node.program.body.unshift(
+        j.importDeclaration(specs, j.stringLiteral('@capsule-ui/react'))
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- expand Tailwind codemod to support more utility classes and dynamic className expressions
- document broader codemod coverage and add guides for styled-system, Bootstrap, and Material UI migrations

## Testing
- `pnpm lint` *(fails: Expected ".container.variant-fullscreen .modal" to have a specificity no more than "0,1,0")*
- `pnpm test` *(fails: # fail 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc03327c4832892d925b375829d52