### PR TITLE
feat: enhance theme registry and integration

### DIFF
--- a/scripts/figma-sync-server.ts
+++ b/scripts/figma-sync-server.ts
@@ -6,6 +6,9 @@ import { promises as fs } from 'fs';
 const port = Number(process.env.FIGMA_SYNC_PORT) || 4141;
 const root = path.join(__dirname, '..');
 const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
+const registryUrl = process.env.THEME_REGISTRY_URL;
+const registryToken = process.env.THEME_REGISTRY_TOKEN;
+const registrySlug = process.env.THEME_REGISTRY_SLUG || 'figma-sync';
 
 const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && req.url === '/tokens') {
@@ -28,9 +31,30 @@ const server = http.createServer(async (req, res) => {
       try {
         await fs.writeFile(tokensPath, body);
         const child = spawn('pnpm', ['tokens:build'], { cwd: root, stdio: 'inherit' });
-        child.on('close', code => {
-          res.statusCode = code === 0 ? 200 : 500;
-          res.end(code === 0 ? 'ok' : 'build failed');
+        child.on('close', async code => {
+          if (code === 0) {
+            if (registryUrl) {
+              try {
+                const tokens = JSON.parse(await fs.readFile(tokensPath, 'utf8'));
+                const base = registryUrl.replace(/\/$/, '');
+                await fetch(`${base}/themes`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    ...(registryToken ? { Authorization: `Bearer ${registryToken}` } : {})
+                  },
+                  body: JSON.stringify({ slug: registrySlug, tokens })
+                });
+              } catch (err) {
+                console.error('Failed to publish theme', err);
+              }
+            }
+            res.statusCode = 200;
+            res.end('ok');
+          } else {
+            res.statusCode = 500;
+            res.end('build failed');
+          }
         });
       } catch (err) {
         res.statusCode = 500;

--- a/scripts/registry-theme-loader.mjs
+++ b/scripts/registry-theme-loader.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { ThemeManager } from '../packages/core/theme-manager.js';
+
+function flatten(obj, prefix = []) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      Object.assign(out, flatten(v, [...prefix, k]));
+    } else {
+      out[[...prefix, k].join('-')] = v;
+    }
+  }
+  return out;
+}
+
+const [,, tenant, theme, registryUrl] = process.argv;
+
+if (!tenant || !theme || !registryUrl) {
+  console.error('Usage: node scripts/registry-theme-loader.mjs <tenant> <theme-slug> <registry-url>');
+  process.exit(1);
+}
+
+const base = registryUrl.replace(/\/$/, '');
+const res = await fetch(`${base}/themes/${theme}`);
+if (!res.ok) {
+  console.error(`Failed to fetch theme: ${res.status}`);
+  process.exit(1);
+}
+const json = await res.json();
+const vars = flatten(json);
+ThemeManager.registerTheme(tenant, theme, vars);

--- a/theme-registry/README.md
+++ b/theme-registry/README.md
@@ -32,3 +32,40 @@ curl http://localhost:8080/themes/acme
 
 Theme files are stored in `theme-registry/themes/<slug>.json` and can
 be consumed at runtime via their URL.
+
+## Authentication
+
+Set a `THEME_REGISTRY_TOKEN` environment variable to require a bearer
+token for `POST /themes` requests:
+
+```bash
+THEME_REGISTRY_TOKEN=secret node theme-registry/server.mjs
+```
+
+Then include the token when uploading themes:
+
+```bash
+curl -X POST http://localhost:8080/themes \
+  -H 'Authorization: Bearer secret' \
+  -H 'Content-Type: application/json' \
+  -d '{"slug":"acme","tokens":{"color":{"brand":"#ff3b3b"}}}'
+```
+
+## CDN integration
+
+If your themes are mirrored to a CDN, set `THEME_REGISTRY_BASE_URL` to
+the CDN origin so theme URLs returned by the service point there:
+
+```bash
+THEME_REGISTRY_BASE_URL=https://cdn.example.com/capsule \
+  node theme-registry/server.mjs
+```
+
+## Consuming themes
+
+Use the `registry-theme-loader` script to fetch a theme from the
+registry and register it with the `ThemeManager` API:
+
+```bash
+node scripts/registry-theme-loader.mjs <tenant> <theme-slug> <registry-url>
+```

--- a/theme-registry/server.mjs
+++ b/theme-registry/server.mjs
@@ -6,9 +6,18 @@ import { randomUUID } from 'node:crypto';
 const themesDir = path.join(process.cwd(), 'theme-registry', 'themes');
 await fs.mkdir(themesDir, { recursive: true });
 
+const authToken = process.env.THEME_REGISTRY_TOKEN;
+const baseUrl = (process.env.THEME_REGISTRY_BASE_URL || '').replace(/\/$/, '');
+
 function send(res, status, data) {
   res.writeHead(status, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify(data));
+}
+
+function sanitizeSlug(slug) {
+  const s = String(slug).toLowerCase().replace(/[^a-z0-9-]/g, '');
+  if (!s) throw new Error('invalid slug');
+  return s;
 }
 
 const server = createServer(async (req, res) => {
@@ -19,7 +28,8 @@ const server = createServer(async (req, res) => {
       .filter((f) => f.endsWith('.json'))
       .map((f) => {
         const slug = f.replace(/\.json$/i, '');
-        return { slug, url: `/themes/${slug}` };
+        const url = `${baseUrl}/themes/${slug}`;
+        return { slug, url };
       });
     return send(res, 200, themes);
   }
@@ -35,19 +45,23 @@ const server = createServer(async (req, res) => {
     }
   }
   if (req.method === 'POST' && url.pathname === '/themes') {
+    if (authToken && req.headers.authorization !== `Bearer ${authToken}`) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
     let body = '';
     req.on('data', (chunk) => (body += chunk));
     req.on('end', async () => {
       try {
         const data = JSON.parse(body);
-        const slug = data.slug || randomUUID();
+        const slug = sanitizeSlug(data.slug || randomUUID());
         const file = path.join(themesDir, `${slug}.json`);
         try {
           await fs.access(file);
           return send(res, 409, { error: 'slug exists' });
         } catch {
           await fs.writeFile(file, JSON.stringify(data.tokens || data, null, 2));
-          return send(res, 201, { slug, url: `/themes/${slug}` });
+          const url = `${baseUrl}/themes/${slug}`;
+          return send(res, 201, { slug, url });
         }
       } catch {
         return send(res, 400, { error: 'invalid JSON' });


### PR DESCRIPTION
## Summary
- add bearer auth and CDN URL support to theme registry
- allow Figma sync server to publish tokens to registry
- add script to load registry themes into ThemeManager

## Testing
- `pnpm test` *(fails: 58 passing, 2 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc016df1083289f2f0567bdf39695