### PR TITLE
docs: expand demos and add design guidelines

### DIFF
--- a/docs/analytics-error-reporting.md
+++ b/docs/analytics-error-reporting.md
@@ -2,6 +2,12 @@
 
 Capsule UI exposes opt-in hooks to record anonymous usage metrics and report runtime errors.
 
+## Guidelines
+
+- Enable analytics only with user consent and keep it disabled in development.
+- Route error reports to a centralized service and tag them with tenant identifiers.
+- In tests, stub analytics and error handlers to avoid noisy output.
+
 ## Usage analytics
 
 ```js

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -7,15 +7,15 @@ Simple surface container with adjustable padding via container queries.
 ### Web Component
 
 ```html
-<caps-card>Content</caps-card>
-<caps-card variant="outline">No shadow</caps-card>
+<caps-card><p>Card body</p></caps-card>
+<caps-card variant="outline"><p>No shadow</p></caps-card>
 ```
 
 ### CSS Modules
 
 ```html
-<div class="card">Content</div>
-<div class="card" data-variant="outline">No shadow</div>
+<div class="card"><p>Card body</p></div>
+<div class="card" data-variant="outline"><p>No shadow</p></div>
 ```
 
 Import `card.module.css` and apply the exported `card` class.
@@ -27,6 +27,10 @@ Import `card.module.css` and apply the exported `card` class.
 - **Attributes**: `variant`
 
 Padding scales up when the card's container is `600px` or wider.
+
+## Demo
+
+<iframe src="https://storybook.capsule-ui.com/iframe.html?id=components-card--default" style="width:100%;height:400px;border:1px solid #eee;"></iframe>
 
 ## A11y
 

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -28,6 +28,10 @@ Import `input.module.css` and apply the exported `input` class.
 
 Padding increases when its container width reaches `480px`.
 
+## Demo
+
+<iframe src="https://storybook.capsule-ui.com/iframe.html?id=components-input--default" style="width:100%;height:400px;border:1px solid #eee;"></iframe>
+
 ## A11y
 
 - Pair with a `<label for="...">` to provide a programmatic name.

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -8,7 +8,7 @@ Modal dialog that can expand to fullscreen and resizes based on container.
 
 ```html
 <caps-modal id="m">
-  <p>Hi</p>
+  <p>Dialog content</p>
 </caps-modal>
 <caps-button onclick="m.setAttribute('open','')">Open</caps-button>
 ```
@@ -18,7 +18,7 @@ Modal dialog that can expand to fullscreen and resizes based on container.
 ```html
 <div class="container" id="m">
   <div class="backdrop"></div>
-  <div class="modal">Hi</div>
+  <div class="modal">Dialog content</div>
 </div>
 <caps-button onclick="m.setAttribute('open','')">Open</caps-button>
 ```
@@ -32,6 +32,10 @@ Import `modal.module.css` and apply the exported classes `container`, `backdrop`
 - **Attributes**: `open`, `variant`
 
 Setting `variant="fullscreen"` makes the dialog cover the viewport. The modal's minimum width grows when the container is wider than `600px`.
+
+## Demo
+
+<iframe src="https://storybook.capsule-ui.com/iframe.html?id=components-modal--default" style="width:100%;height:400px;border:1px solid #eee;"></iframe>
 
 ## A11y
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -40,6 +40,10 @@ Import `select.module.css` and apply the exported `select` class.
 
 Padding adjusts when the container is at least `480px` wide.
 
+## Demo
+
+<iframe src="https://storybook.capsule-ui.com/iframe.html?id=components-select--default" style="width:100%;height:400px;border:1px solid #eee;"></iframe>
+
 ## A11y
 
 - Pair with a `<label for="...">` to provide a programmatic name.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -40,6 +40,10 @@ Import `tabs.module.css` and apply the exported classes.
 
 When the container is narrower than `480px` the tab list stacks vertically.
 
+## Demo
+
+<iframe src="https://storybook.capsule-ui.com/iframe.html?id=components-tabs--default" style="width:100%;height:400px;border:1px solid #eee;"></iframe>
+
 ## A11y
 
 - Tab buttons are given proper `role` and keyboard navigation.

--- a/docs/container-queries.md
+++ b/docs/container-queries.md
@@ -1,0 +1,33 @@
+# Container queries
+
+Capsule components rely on CSS `@container` rules to adapt to the size
+of their host element instead of the viewport. Each component defines a
+logical container so padding, layout and orientation respond to local
+space.
+
+## Approach
+
+- Scope queries to the smallest element that needs them to limit style
+  recalculations.
+- Use semantic breakpoints like `--caps-size-md` instead of hard-coded
+  pixel values when possible.
+
+## Testing
+
+Use a browser automation tool to resize the component's container and
+assert style changes. Example with Playwright:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('card padding updates at 600px', async ({ page }) => {
+  await page.goto('/examples/index.html');
+  const card = page.locator('caps-card').first();
+  await card.evaluate(el => (el.style.width = '400px'));
+  await expect(card).toHaveCSS('padding', '16px');
+  await card.evaluate(el => (el.style.width = '700px'));
+  await expect(card).toHaveCSS('padding', '24px');
+});
+```
+
+Include these checks in CI to ensure responsive behaviour stays intact.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,11 @@ design guidelines, migration tips and the philosophy behind Capsule.
 
 - [Component demos](components/)
 - [Framework adapters](framework-adapters.md)
+- [Theming guide](theming.md)
+- [Multi-tenant design](multi-tenant-design.md)
+- [Analytics & error reporting](analytics-error-reporting.md)
 - [Theming lab](theming-lab)
+- [Container queries](container-queries.md)
 - [Accessibility checklist](a11y-checklist.md)
 
 Check the [roadmap](../ROADMAP.md) for upcoming work and the blog for release

--- a/docs/multi-tenant-design.md
+++ b/docs/multi-tenant-design.md
@@ -1,0 +1,25 @@
+# Multi-tenant design
+
+Capsule UI can serve multiple tenants from a single deployment. Keep
+styles, data and metrics isolated so tenants cannot affect each other.
+
+## Theme isolation
+
+- Provide a token preset per tenant and load it with `setTheme`.
+- Mount each tenant's UI in a Shadow DOM root to prevent style leaks.
+
+## Configuration
+
+- Fetch tenant configuration at runtime instead of bundling it.
+- Avoid caching sensitive tenant data in shared storage.
+
+## Metrics and errors
+
+Tag analytics and error reports with a tenant identifier using the
+hooks described in [analytics-error-reporting.md](analytics-error-reporting.md).
+Store logs separately if regulations require data separation.
+
+## Testing
+
+Run unit, accessibility and visual tests for every tenant preset to
+ensure consistent behaviour across configurations.

--- a/docs/ssr-seo.md
+++ b/docs/ssr-seo.md
@@ -18,7 +18,8 @@ ce.textContent = btn.textContent;
 btn.replaceWith(ce);
 ```
 
-Framework integrations under `examples/ssr/` show the pattern for React, Vue and Svelte.
+Framework integrations under [`examples/ssr`](../examples/ssr/) include concrete setups for
+[React](../examples/ssr/react), [Vue](../examples/ssr/vue) and [Svelte](../examples/ssr/svelte).
 Each example inlines precompiled Capsule CSS modules to avoid a flash of unstyled
 content before hydration. The `light-dom` sample illustrates measuring Cumulative Layout
 Shift during upgrade; a passing Playwright test ensures the layout stays stable.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,23 @@
+# Theming guidelines
+
+Capsule UI components read design tokens via CSS custom properties.
+Override tokens at the root or per component to align with your brand.
+Keep overrides small and document the intent.
+
+## Tokens
+
+- Use semantic token names like `color.brand` rather than hex values.
+- Scope overrides to the smallest region that needs them.
+- Prefer theme toggles (light/dark) over one-off overrides.
+
+## Presets and sharing
+
+Use the [theming lab](theming-lab) to experiment with tokens and export
+JSON presets. Store presets in version control or upload them to the
+[theme registry](theme-registry.md) for sharing across teams.
+
+## Testing themes
+
+Run visual regression tests for each preset to ensure components render
+as expected. Combine with accessibility checks to confirm contrast and
+focus states remain compliant.


### PR DESCRIPTION
## Summary
- add Storybook demos across component docs and replace placeholders
- document theming, multi-tenant design, container queries, and analytics guidelines
- link SSR guide to concrete React/Vue/Svelte examples

## Testing
- `pnpm lint` *(fails: selector-max-specificity in modal/tabs CSS)*
- `pnpm test` *(fails: caps-select reflects value and disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbff146808328badea09c09e81a67