### PR TITLE
feat: add SSR CSS loading and performance budgets

### DIFF
--- a/docs/performance-budgets.md
+++ b/docs/performance-budgets.md
@@ -1,0 +1,11 @@
+# Performance Budgets
+
+Capsule enforces budgets for key metrics during continuous integration:
+
+- **Bundle size** – `dist/tokens.js` must not exceed **5KB**. The `check:bundle-size`
+  script fails the build if the budget is exceeded.
+- **Hydration runtime** – upgrading a server-rendered `<button>` to `<caps-button>` must
+  finish in under **50ms** and cause less than **0.01** Cumulative Layout Shift. The
+  `ssr-hydration.spec.js` Playwright test verifies these budgets.
+
+These checks run as part of `pnpm test` in CI.

--- a/docs/ssr-seo.md
+++ b/docs/ssr-seo.md
@@ -19,6 +19,13 @@ btn.replaceWith(ce);
 ```
 
 Framework integrations under `examples/ssr/` show the pattern for React, Vue and Svelte.
-Each example inlines precompiled Capsule CSS modules to avoid a flash of unstyled
-content before hydration. The `light-dom` sample illustrates measuring Cumulative Layout
-Shift during upgrade; a passing Playwright test ensures the layout stays stable.
+CSS for Web Components can be loaded ahead of time with a customized link element:
+
+```html
+<link rel="stylesheet" is="capsule-style" data-module="caps-button" href="/button.css" />
+```
+
+The `capsule-style` element registers the loaded `CSSStyleSheet` so components can
+adopt it during hydration and avoid a flash of unstyled content. The `light-dom`
+sample illustrates measuring Cumulative Layout Shift during upgrade and records the
+hydration time budget with a Playwright test.

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -2,8 +2,9 @@
 
 This directory contains reference integrations for server-side rendering with React, Vue and Svelte.
 Each example renders a Capsule button on the server, hydrates it on the client and demonstrates variant
-styling and basic accessibility attributes. The `light-dom` folder shows how to render plain HTML on the
-server and upgrade it to a Web Component on the client.
+styling and basic accessibility attributes. CSS for Web Components is loaded using a customized
+`<link rel="stylesheet" is='capsule-style'>` element. The `light-dom` folder shows how to render plain
+HTML on the server and upgrade it to a Web Component on the client.
 
 ## Running an Example
 
@@ -15,5 +16,3 @@ pnpm run dev
 ```
 
 Then visit `http://localhost:3000` in a browser to see the hydrated Capsule component.
-
-All examples inline precompiled Capsule CSS to avoid a flash of unstyled content during hydration.

--- a/examples/ssr/light-dom/README.md
+++ b/examples/ssr/light-dom/README.md
@@ -1,7 +1,8 @@
 # Light DOM SSR Example
 
-This example renders a plain `<button>` on the server with precompiled Capsule styles.
-On the client it upgrades the element to `<caps-button>` without causing layout shift.
+This example renders a plain `<button>` on the server with precompiled Capsule styles
+loaded through a custom `<link rel="stylesheet" is='capsule-style'>` element. On the
+client it upgrades the element to `<caps-button>` without causing layout shift.
 
 ## Running
 

--- a/examples/ssr/light-dom/capsule-style.js
+++ b/examples/ssr/light-dom/capsule-style.js
@@ -1,0 +1,20 @@
+export const registry = (globalThis.__capsuleSheets ||= new Map());
+
+class CapsuleStyle extends HTMLLinkElement {
+  connectedCallback() {
+    const module = this.getAttribute('data-module');
+    if (!module) return;
+
+    const register = () => {
+      registry.set(module, this.sheet);
+    };
+
+    if (this.sheet) {
+      register();
+    } else {
+      this.addEventListener('load', register, { once: true });
+    }
+  }
+}
+
+customElements.define('capsule-style', CapsuleStyle, { extends: 'link' });

--- a/examples/ssr/light-dom/server.js
+++ b/examples/ssr/light-dom/server.js
@@ -8,9 +8,23 @@ const buttonCss = readFileSync(
   resolve(__dirname, '../../../packages/core/button.module.css'),
   'utf8'
 );
+const capsuleStyleJs = readFileSync(
+  resolve(__dirname, './capsule-style.js'),
+  'utf8'
+);
 
 export function createServer() {
   return http.createServer((req, res) => {
+    if (req.url === '/button.css') {
+      res.writeHead(200, { 'Content-Type': 'text/css' });
+      res.end(buttonCss);
+      return;
+    }
+    if (req.url === '/capsule-style.js') {
+      res.writeHead(200, { 'Content-Type': 'application/javascript' });
+      res.end(capsuleStyleJs);
+      return;
+    }
     if (req.url && req.url.endsWith('.js')) {
       try {
         const js = readFileSync(
@@ -32,7 +46,8 @@ export function createServer() {
 <head>
 <meta charset="UTF-8">
 <title>Light DOM SSR</title>
-<style>${buttonCss}</style>
+<link rel="stylesheet" is="capsule-style" data-module="caps-button" href="/button.css">
+<script type="module" src="/capsule-style.js"></script>
 <script>
   let cls = 0;
   new PerformanceObserver((list) => {
@@ -41,6 +56,7 @@ export function createServer() {
     }
   }).observe({ type: 'layout-shift', buffered: true });
   window.__getCLS = () => cls;
+  window.__hydrationStart = performance.now();
 </script>
 </head>
 <body>
@@ -51,6 +67,7 @@ export function createServer() {
   const ce = document.createElement('caps-button');
   ce.textContent = btn.textContent;
   btn.replaceWith(ce);
+  window.__hydrationTime = performance.now() - window.__hydrationStart;
 </script>
 </body>
 </html>`);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "pnpm run lint:css && pnpm run lint:js",
     "lint:fix": "pnpm run lint:css --fix && pnpm run lint:js --fix",
     "check:runtime-styles": "node scripts/check-runtime-styles.mjs",
-    "test": "pnpm run build:stylelint-plugin && node --test && pnpm run test:a11y && pnpm run check:runtime-styles && pnpm run test:e2e",    
+    "test": "pnpm run build:stylelint-plugin && node --test && pnpm run test:a11y && pnpm run check:runtime-styles && pnpm run check:bundle-size && pnpm run test:e2e",
     "check:bundle-size": "node scripts/check-bundle-size.mjs",
     "new:component": "node scripts/new-component.mjs",
     "test:a11y": "node scripts/a11y-check.mjs",

--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -1,49 +1,53 @@
 import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
+const css = `
+  :host {
+    display: inline-block;
+    container-type: inline-size;
+  }
+
+  button {
+    font: inherit;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--color-brand);
+    color: var(--color-text);
+    transition: background var(--motion-fast), color var(--motion-fast);
+  }
+  :host([variant="outline"]) button {
+    background: transparent;
+    border: 1px solid var(--color-brand);
+    color: var(--color-brand);
+  }
+  @container (min-width: 480px) {
+    button { padding: var(--spacing-md) var(--spacing-xl); }
+  }
+  button:focus-visible { outline: 2px solid var(--color-text); outline-offset: 2px; }
+  button[disabled] { opacity: 0.6; cursor: not-allowed; }
+  @media (prefers-reduced-motion: reduce) {
+    :host { --motion-fast: 0s; }
+  }
+  @media (prefers-contrast: more) {
+    button {
+      background: var(--color-text);
+      color: var(--color-background);
+    }
+  }
+`;
+
 class CapsButton extends withLocaleDir(HTMLElement) {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    this.shadowRoot.innerHTML = `
-      <style>
-
-        :host {
-          display: inline-block;
-          container-type: inline-size;
-        }
-
-        button {
-          font: inherit;
-          padding: var(--spacing-sm) var(--spacing-lg);
-          border: none;
-          border-radius: var(--radius-md);
-          background: var(--color-brand);
-          color: var(--color-text);
-          transition: background var(--motion-fast), color var(--motion-fast);
-        }
-        :host([variant="outline"]) button {
-          background: transparent;
-          border: 1px solid var(--color-brand);
-          color: var(--color-brand);
-        }
-        @container (min-width: 480px) {
-          button { padding: var(--spacing-md) var(--spacing-xl); }
-        }
-        button:focus-visible { outline: 2px solid var(--color-text); outline-offset: 2px; }
-        button[disabled] { opacity: 0.6; cursor: not-allowed; }
-        @media (prefers-reduced-motion: reduce) {
-          :host { --motion-fast: 0s; }
-        }
-        @media (prefers-contrast: more) {
-          button {
-            background: var(--color-text);
-            color: var(--color-background);
-          }
-        }
-      </style>
-      <button part="button" type="button"><slot></slot></button>
-    `;
+    const sheet = globalThis.__capsuleSheets?.get?.('caps-button');
+    if (sheet) {
+      this.shadowRoot.adoptedStyleSheets = [sheet];
+      this.shadowRoot.innerHTML = `<button part="button" type="button"><slot></slot></button>`;
+    } else {
+      this.shadowRoot.innerHTML = `<style>${css}</style><button part="button" type="button"><slot></slot></button>`;
+    }
   }
 
   static get observedAttributes() {

--- a/tests/ssr-hydration.spec.js
+++ b/tests/ssr-hydration.spec.js
@@ -17,7 +17,9 @@ test('upgrades light DOM without layout shift', async ({ page }) => {
   await page.goto(`http://localhost:${port}`);
   await page.waitForSelector('caps-button');
   const cls = await page.evaluate(() => window.__getCLS());
+  const hydration = await page.evaluate(() => window.__hydrationTime);
   expect(cls).toBeLessThan(0.01);
+  expect(hydration).toBeLessThan(50);
   const tag = await page.locator('caps-button').evaluate((el) => el.tagName);
   expect(tag).toBe('CAPS-BUTTON');
 });


### PR DESCRIPTION
## Summary
- document loading component CSS during SSR via a customized `<link is="capsule-style">`
- add `capsule-style` element and update light DOM SSR example with hydration timing
- enforce bundle-size and hydration runtime budgets in CI

## Testing
- `pnpm test` *(fails: Token schema validation failed)*
- `pnpm run check:bundle-size`
- `pnpm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0114ed48328a14a3450857b4a67