### PR TITLE
feat: improve i18n and accessibility

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -36,3 +36,12 @@ Container query: padding grows when the button's container is at least `480px` w
 
 - Uses native `<button>` semantics so keyboard and screen-reader behaviour follow platform defaults.
 - Set `aria-label` when the button has no text content.
+- Example:
+
+```html
+<caps-button aria-label="Add item">
+  <svg aria-hidden="true"><!-- icon --></svg>
+</caps-button>
+```
+
+- Activate the button with `Enter` or `Space`.

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -32,3 +32,11 @@ Padding increases when its container width reaches `480px`.
 
 - Pair with a `<label for="...">` to provide a programmatic name.
 - Focus outline follows platform defaults.
+- Example:
+
+```html
+<label for="email">Email</label>
+<caps-input id="email"></caps-input>
+```
+
+- Move focus with `Tab`/`Shift+Tab` like a native `<input>`.

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -37,3 +37,13 @@ Setting `variant="fullscreen"` makes the dialog cover the viewport. The modal's 
 
 - Focus is trapped when open and returned to the trigger on close.
 - Clicking the backdrop or pressing `Escape` closes the dialog.
+- Example:
+
+```html
+<caps-modal aria-labelledby="dialog-title">
+  <h2 id="dialog-title">Confirm</h2>
+  <p>Are you sure?</p>
+</caps-modal>
+```
+
+- Use `Tab`/`Shift+Tab` to cycle focus within the dialog.

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -44,3 +44,14 @@ Padding adjusts when the container is at least `480px` wide.
 
 - Pair with a `<label for="...">` to provide a programmatic name.
 - Uses native `<select>` semantics so keyboard and screen-reader behavior follow platform defaults.
+- Example:
+
+```html
+<label for="fruit">Fruit</label>
+<caps-select id="fruit">
+  <option value="a">Apple</option>
+  <option value="b">Banana</option>
+</caps-select>
+```
+
+- Open the list with `Alt+Down` and navigate options with arrow keys.

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -44,3 +44,15 @@ When the container is narrower than `480px` the tab list stacks vertically.
 
 - Tab buttons are given proper `role` and keyboard navigation.
 - Remember to label the tab list if necessary via `aria-label`.
+- Example:
+
+```html
+<caps-tabs aria-label="Sample tabs">
+  <button slot="tab">One</button>
+  <button slot="tab">Two</button>
+  <div slot="panel">First panel</div>
+  <div slot="panel">Second panel</div>
+</caps-tabs>
+```
+
+- Use arrow keys to move between tabs and `Home`/`End` to jump.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -31,3 +31,17 @@ formatters.
 
 The [`examples/rtl.html`](../examples/rtl.html) file demonstrates switching
 locales at runtime and how components respond to RTL layouts.
+
+## Locale-aware date picker
+
+```html
+<label for="birthday">Birthday</label>
+<input id="birthday" type="date" aria-label="Choose date" />
+<script type="module">
+  import { formatDate } from '@capsule-ui/core';
+  const input = document.getElementById('birthday');
+  input.value = formatDate(new Date(), { year: 'numeric', month: '2-digit', day: '2-digit' });
+</script>
+```
+
+`formatDate` ensures the initial value respects the current locale.

--- a/packages/core/withLocaleDir.js
+++ b/packages/core/withLocaleDir.js
@@ -4,13 +4,14 @@ export function withLocaleDir(Base = HTMLElement) {
   return class extends Base {
     connectedCallback() {
       if (super.connectedCallback) super.connectedCallback();
-      if (!this.hasAttribute('dir')) {
+      this._autoDir = !this.hasAttribute('dir');
+      if (this._autoDir) {
         this.setAttribute('dir', getLocale().dir);
-        this._unsubLocale = onLocaleChange((loc) => {
-          if (!this.hasAttribute('dir')) this.setAttribute('dir', loc.dir);
-          this.localeDirChanged?.(loc);
-        });
       }
+      this._unsubLocale = onLocaleChange((loc) => {
+        if (this._autoDir) this.setAttribute('dir', loc.dir);
+        this.localeDirChanged?.(loc);
+      });
     }
 
     disconnectedCallback() {

--- a/tests/button-a11y.test.js
+++ b/tests/button-a11y.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+test('caps-button forwards aria attributes', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.CustomEvent = dom.window.CustomEvent;
+
+  await import('../packages/core/button.js');
+
+  const el = document.createElement('caps-button');
+  el.setAttribute('aria-label', 'save');
+  el.disabled = true;
+  document.body.appendChild(el);
+
+  const internal = el.shadowRoot.querySelector('button');
+  assert.equal(internal.getAttribute('aria-label'), 'save');
+  assert.equal(internal.getAttribute('aria-disabled'), 'true');
+});

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -8,6 +8,8 @@ test('caps-select reflects value and disabled', async () => {
   global.document = dom.window.document;
   global.HTMLElement = dom.window.HTMLElement;
   global.customElements = dom.window.customElements;
+  global.Node = dom.window.Node;
+  global.Element = dom.window.Element;
 
   await import('../packages/core/select.js');
 

--- a/tests/tabs-rtl.test.js
+++ b/tests/tabs-rtl.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+function key(el, key, win) {
+  el.dispatchEvent(new win.KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+test('caps-tabs arrow key navigation flips in RTL', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.CustomEvent = dom.window.CustomEvent;
+  global.Node = dom.window.Node;
+  global.Element = dom.window.Element;
+
+  const locale = await import('../packages/core/locale.js');
+  await import('../packages/core/tabs.js');
+
+  const tabs = document.createElement('caps-tabs');
+  const t1 = document.createElement('button');
+  t1.setAttribute('slot', 'tab');
+  t1.textContent = 'One';
+  const t2 = document.createElement('button');
+  t2.setAttribute('slot', 'tab');
+  t2.textContent = 'Two';
+  const p1 = document.createElement('div');
+  p1.setAttribute('slot', 'panel');
+  p1.textContent = 'A';
+  const p2 = document.createElement('div');
+  p2.setAttribute('slot', 'panel');
+  p2.textContent = 'B';
+  tabs.append(t1, t2, p1, p2);
+  document.body.appendChild(tabs);
+
+  // LTR: ArrowRight moves from first to second tab
+  key(t1, 'ArrowRight', dom.window);
+  assert.equal(t2.getAttribute('aria-selected'), 'true');
+
+  // RTL: ArrowRight moves from second back to first
+  locale.setLocale({ dir: 'rtl' });
+  await new Promise((r) => setTimeout(r, 0));
+  key(t2, 'ArrowRight', dom.window);
+  assert.equal(t1.getAttribute('aria-selected'), 'true');
+});

--- a/tests/withLocaleDir.test.js
+++ b/tests/withLocaleDir.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+
+test('components update dir when locale changes', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.CustomEvent = dom.window.CustomEvent;
+
+  const locale = await import('../packages/core/locale.js');
+  await import('../packages/core/button.js');
+
+  const el = document.createElement('caps-button');
+  document.body.appendChild(el);
+  assert.equal(el.getAttribute('dir'), 'ltr');
+
+  locale.setLocale({ dir: 'rtl' });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(el.getAttribute('dir'), 'rtl');
+
+  const el2 = document.createElement('caps-button');
+  el2.setAttribute('dir', 'ltr');
+  document.body.appendChild(el2);
+  locale.setLocale({ dir: 'rtl' });
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(el2.getAttribute('dir'), 'ltr');
+});


### PR DESCRIPTION
## Summary
- refresh locale direction mixin to update components automatically
- document ARIA labelling and keyboard use for core components
- add tests covering locale direction and RTL keyboard behaviour

## Testing
- `pnpm test` *(fails: 1 failing test)*
- `pnpm run test:a11y` *(fails: Could not find expected browser (chrome))*
- `pnpm run check:runtime-styles`
- `pnpm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc0082f7083289042778e2eebd7a4