### PR TITLE
feat: expose core css modules

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,13 @@
     "./select.recipe": {
       "import": "./select.recipe.js",
       "types": "./select.recipe.d.ts"
-    }
+    },
+    "./button.module.css": "./button.module.css",
+    "./card.module.css": "./card.module.css",
+    "./input.module.css": "./input.module.css",
+    "./tabs.module.css": "./tabs.module.css",
+    "./modal.module.css": "./modal.module.css",
+    "./select.module.css": "./select.module.css"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1"

--- a/packages/css/index.d.ts
+++ b/packages/css/index.d.ts
@@ -1,6 +1,36 @@
-export const button: { readonly button: string };
-export const input: { readonly input: string };
-export const card: { readonly card: string };
-export const tabs: { readonly tabs: string };
-export const modal: { readonly modal: string };
-export const select: { readonly select: string };
+export const button: {
+  readonly button: string;
+  readonly "variant-outline": string;
+  readonly "variant-secondary": string;
+  readonly "variant-danger": string;
+  readonly "size-sm": string;
+  readonly "size-lg": string;
+};
+export const input: {
+  readonly input: string;
+  readonly "variant-outline": string;
+};
+export const card: {
+  readonly card: string;
+  readonly "variant-outline": string;
+  readonly "variant-ghost": string;
+  readonly "size-compact": string;
+};
+export const tabs: {
+  readonly tabs: string;
+  readonly tablist: string;
+  readonly tab: string;
+  readonly panels: string;
+  readonly panel: string;
+  readonly "variant-pill": string;
+};
+export const modal: {
+  readonly container: string;
+  readonly backdrop: string;
+  readonly modal: string;
+  readonly "variant-fullscreen": string;
+};
+export const select: {
+  readonly select: string;
+  readonly "variant-outline": string;
+};


### PR DESCRIPTION
## Summary
- export CSS module files for all core components
- expand CSS module type declarations to cover variant and subpart classes

## Testing
- `pnpm lint` *(fails: 'css' unused and 'figma' not defined in unrelated files)*
- `pnpm test` *(fails: Identifier 'doc' has already been declared in tests/scaffold-component.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3e77fcc8328b4e32b03f6cc6c29