### PR TITLE
perf: add size budgets and layout containment

### DIFF
--- a/packages/core/instrument.js
+++ b/packages/core/instrument.js
@@ -4,12 +4,18 @@ import { reportError } from './error-reporting.js';
 export function instrumentComponent(name, ctor, { variantAttr = 'variant' } = {}) {
   const originalConnected = ctor.prototype.connectedCallback;
   ctor.prototype.connectedCallback = function (...args) {
+    const start = typeof performance !== 'undefined' ? performance.now() : undefined;
     try {
       trackComponent(name, this.getAttribute(variantAttr));
       return originalConnected?.apply(this, args);
     } catch (err) {
       reportError(err);
       throw err;
+    } finally {
+      if (start !== undefined) {
+        const duration = performance.now() - start;
+        console.debug(`[capsule:perf] ${name}.connectedCallback ${duration.toFixed(2)}ms`);
+      }
     }
   };
 
@@ -17,11 +23,17 @@ export function instrumentComponent(name, ctor, { variantAttr = 'variant' } = {}
     const original = ctor.prototype[method];
     if (typeof original === 'function') {
       ctor.prototype[method] = function (...args) {
+        const start = typeof performance !== 'undefined' ? performance.now() : undefined;
         try {
           return original.apply(this, args);
         } catch (err) {
           reportError(err);
           throw err;
+        } finally {
+          if (start !== undefined) {
+            const duration = performance.now() - start;
+            console.debug(`[capsule:perf] ${name}.${method} ${duration.toFixed(2)}ms`);
+          }
         }
       };
     }

--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -14,6 +14,8 @@ class CapsModal extends withLocaleDir(HTMLElement) {
           position: fixed;
           inset: 0;
           container-type: inline-size;
+          contain: layout paint;
+          content-visibility: auto;
         }
         :host([open]) { display: block; }
         .backdrop { position: absolute; inset: 0; background: var(--color-overlay); }
@@ -26,6 +28,8 @@ class CapsModal extends withLocaleDir(HTMLElement) {
           padding: var(--spacing-lg);
           border-radius: var(--radius-lg);
           min-width: 300px;
+          contain: layout paint;
+          content-visibility: auto;
         }
         :host([variant="fullscreen"]) .modal {
           inset: 0;

--- a/packages/core/modal.module.css
+++ b/packages/core/modal.module.css
@@ -5,6 +5,8 @@
   inset: 0;
   container-type: inline-size;
   --motion-fast: 0.2s;
+  contain: layout paint;
+  content-visibility: auto;
 }
 .container:where([open]) {
   display: block;
@@ -24,6 +26,8 @@
   border-radius: var(--radius-lg);
   min-width: 300px;
   transition: transform var(--motion-fast);
+  contain: layout paint;
+  content-visibility: auto;
 }
 @media (prefers-reduced-motion: reduce) {
   .container { --motion-fast: 0s; }

--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -11,6 +11,8 @@ class CapsTabs extends withLocaleDir(HTMLElement) {
         :host {
           display: block;
           container-type: inline-size;
+          contain: layout paint;
+          content-visibility: auto;
         }
         .tablist { display: flex; gap: var(--spacing-xs); }
         .tablist ::slotted(button) {
@@ -32,8 +34,13 @@ class CapsTabs extends withLocaleDir(HTMLElement) {
           border: 1px solid var(--color-border);
           border-radius: 0 0 var(--radius-md) var(--radius-md);
           padding: var(--spacing-lg);
+          contain: layout paint;
         }
-        .panels ::slotted(*) { display: none; }
+        .panels ::slotted(*) {
+          display: none;
+          contain: layout paint;
+          content-visibility: auto;
+        }
         .panels ::slotted([data-active]) { display: block; }
         @container (max-width: 480px) {
           .tablist { flex-direction: column; }

--- a/packages/core/tabs.module.css
+++ b/packages/core/tabs.module.css
@@ -29,9 +29,12 @@
   border: 1px solid var(--color-border);
   border-radius: 0 0 var(--radius-md) var(--radius-md);
   padding: var(--spacing-lg);
+  contain: layout paint;
 }
 .panel {
   display: none;
+  contain: layout paint;
+  content-visibility: auto;
 }
 .panel:where([data-active]) {
   display: block;

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,18 +1,31 @@
 import fs from 'fs';
 import path from 'path';
 
-const bundlePath = path.resolve('dist', 'tokens.js');
-const maxBytes = 5 * 1024; // 5KB budget
+const budgets = [
+  { file: path.resolve('dist', 'tokens.js'), maxBytes: 5 * 1024 },
+  { file: path.resolve('dist', 'tokens.css'), maxBytes: 5 * 1024 },
+  { file: path.resolve('packages', 'core', 'modal.js'), maxBytes: 6 * 1024 },
+  { file: path.resolve('packages', 'core', 'modal.module.css'), maxBytes: 2 * 1024 },
+  { file: path.resolve('packages', 'core', 'tabs.js'), maxBytes: 6 * 1024 },
+  { file: path.resolve('packages', 'core', 'tabs.module.css'), maxBytes: 2 * 1024 }
+];
 
-try {
-  const { size } = fs.statSync(bundlePath);
-  if (size > maxBytes) {
-    console.error(`Bundle size ${size} exceeds budget of ${maxBytes} bytes`);
-    process.exit(1);
-  } else {
-    console.log(`Bundle size ${size} within budget (${maxBytes} bytes)`);
+let withinBudget = true;
+for (const { file, maxBytes } of budgets) {
+  try {
+    const { size } = fs.statSync(file);
+    if (size > maxBytes) {
+      console.error(`Bundle size ${file} ${size} exceeds budget of ${maxBytes} bytes`);
+      withinBudget = false;
+    } else {
+      console.log(`Bundle size ${file} ${size} within budget (${maxBytes} bytes)`);
+    }
+  } catch (err) {
+    console.error(`Unable to check bundle size at ${file}:`, err.message);
+    withinBudget = false;
   }
-} catch (err) {
-  console.error(`Unable to check bundle size at ${bundlePath}:`, err.message);
+}
+
+if (!withinBudget) {
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- enforce bundle size budgets for core components and tokens
- profile component lifecycle methods to surface layout costs
- use CSS `content-visibility` and `contain` for modal and tabs to isolate layout work

## Testing
- `pnpm test` *(fails: not ok 11 - /workspace/Capsule-UI/tests/scaffold-component.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4a5d19c83289893c84718b5d6aa