### PR TITLE
feat: add safe event dispatch and theme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For developers migrating from Tailwind or CSS‑in‑JS, see the [migration and 
 - **Isolation by default.** Your host CSS can’t leak in; component CSS can’t leak out.
 - **Theming at runtime.** Flip brands/tenants by setting CSS variables—no rebuilds.
 - **Tenant isolation.** `ThemeManager` scopes tokens per tenant so styles can't leak across boundaries.
+- **Micro-frontend ready.** Register and remove tenant styles on the fly.
+- **Secure events.** `dispatchSafeEvent` keeps custom events inside component boundaries.
 - **Predictable overrides.** Only what you expose is customizable (`::part`, CSS vars).
 - **Fast.** Plain CSS or compile-time utilities; zero runtime styling engine.
 - **Local responsiveness.** Container queries adapt to *the space you give the component*.
@@ -230,6 +232,10 @@ import { ThemeManager } from '@capsule-ui/core';
 
 await ThemeManager.load('tenantA', '/themes/tenant-a.json');
 ThemeManager.applyTheme('tenantA', 'dark');
+
+// Later, when tearing down a micro-frontend:
+ThemeManager.unregister('tenantA');
+ThemeManager.reset();
 ```
 
 ### Theming lab
@@ -243,6 +249,18 @@ Shareable presets can be uploaded to a lightweight [theme registry](docs/theme-r
 Each upload receives a unique URL that teams can reference at runtime or package for
 distribution on npm. Browse, fetch, and reuse themes without copying token files
 between projects.
+
+### Secure custom events
+
+Use `dispatchSafeEvent` to emit sanitized custom events that stay inside the
+component's shadow DOM by default. This prevents accidental leakage across
+micro-frontend boundaries:
+
+```js
+import { dispatchSafeEvent } from '@capsule-ui/core';
+
+dispatchSafeEvent(el, 'capsule:change', { value });
+```
 
 ---
 

--- a/packages/core/events.js
+++ b/packages/core/events.js
@@ -1,0 +1,15 @@
+const eventNameRe = /^[a-z0-9:-]+$/i;
+
+export function dispatchSafeEvent(target, name, detail = {}, options = {}) {
+  const sanitized = String(name).replace(/[^a-z0-9:-]/gi, '-');
+  if (!eventNameRe.test(sanitized)) {
+    throw new Error(`Invalid event name: ${name}`);
+  }
+  const {
+    bubbles = true,
+    composed = false,
+  } = options;
+  const event = new CustomEvent(sanitized, { detail, bubbles, composed });
+  target.dispatchEvent(event);
+  return event;
+}

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -17,3 +17,4 @@ export { setTheme, getTheme, onThemeChange } from './theme.js';
 export { enableAnalytics, disableAnalytics } from './analytics.js';
 export { enableErrorReporting, disableErrorReporting } from './error-reporting.js';
 export { sanitizeNode, sanitizeHTML } from './sanitize.js';
+export { dispatchSafeEvent } from './events.js';

--- a/packages/core/locale.js
+++ b/packages/core/locale.js
@@ -1,3 +1,5 @@
+import { dispatchSafeEvent } from './events.js';
+
 let current =
   typeof document !== 'undefined'
     ? {
@@ -26,7 +28,7 @@ export function setLocale({ lang, dir } = {}) {
     current.dir = dir;
   }
   if (typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent(EVENT, { detail: { ...current } }));
+    dispatchSafeEvent(window, EVENT, { ...current }, { bubbles: false });
   }
 }
 

--- a/packages/core/theme-manager.js
+++ b/packages/core/theme-manager.js
@@ -81,4 +81,22 @@ export class ThemeManager {
     element.setAttribute('data-tenant', tenant);
     element.setAttribute('data-theme', theme);
   }
+
+  static unregister(tenant) {
+    if (typeof document === 'undefined') return;
+    const id = `caps-theme-${sanitizeName(tenant)}`;
+    document.getElementById(id)?.remove();
+  }
+
+  static unregisterTheme(tenant, theme) {
+    if (typeof document === 'undefined') return;
+    const id = `caps-theme-${sanitizeName(tenant)}-${sanitizeName(theme)}`;
+    document.getElementById(id)?.remove();
+  }
+
+  static reset(element = document.documentElement) {
+    if (typeof document === 'undefined') return;
+    element.removeAttribute('data-tenant');
+    element.removeAttribute('data-theme');
+  }
 }

--- a/tests/events.test.js
+++ b/tests/events.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('dispatchSafeEvent sanitizes event names and defaults', async () => {
+  const { dispatchSafeEvent } = await import('../packages/core/events.js');
+  const target = new EventTarget();
+  let received = false;
+  target.addEventListener('caps-test', (e) => {
+    received = e.detail.value === 42 && e.bubbles === false && e.composed === false;
+  });
+  dispatchSafeEvent(target, 'caps test', { value: 42 }, { bubbles: false });
+  assert.ok(received);
+});
+
+test('dispatchSafeEvent sanitizes invalid names', async () => {
+  const { dispatchSafeEvent } = await import('../packages/core/events.js');
+  const target = new EventTarget();
+  let fired = false;
+  target.addEventListener('bad-name', () => {
+    fired = true;
+  });
+  dispatchSafeEvent(target, 'bad/name');
+  assert.ok(fired);
+});

--- a/tests/theme-manager.test.js
+++ b/tests/theme-manager.test.js
@@ -91,3 +91,31 @@ test('ThemeManager sanitizes invalid tenant and theme names', async () => {
   assert.ok(style.includes('[data-tenant="foo-bar"][data-theme="dark-mode"]'));
 });
 
+test('ThemeManager can unregister themes and reset attributes', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const { ThemeManager } = await import('../packages/core/theme-manager.js');
+
+  ThemeManager.register('acme', { 'caps-btn-bg': 'pink' });
+  ThemeManager.registerTheme('acme', 'dark', { 'caps-btn-bg': 'purple' });
+
+  let style = document.getElementById('caps-theme-acme');
+  assert.ok(style);
+  ThemeManager.unregister('acme');
+  style = document.getElementById('caps-theme-acme');
+  assert.equal(style, null);
+
+  const el = document.createElement('div');
+  ThemeManager.applyTheme('acme', 'dark', el);
+  assert.equal(el.getAttribute('data-tenant'), 'acme');
+  assert.equal(el.getAttribute('data-theme'), 'dark');
+  ThemeManager.reset(el);
+  assert.equal(el.getAttribute('data-tenant'), null);
+  assert.equal(el.getAttribute('data-theme'), null);
+  ThemeManager.unregisterTheme('acme', 'dark');
+  style = document.getElementById('caps-theme-acme-dark');
+  assert.equal(style, null);
+});
+


### PR DESCRIPTION
## Summary
- add `dispatchSafeEvent` utility and export from core
- support unregistering tenant styles and resetting applied themes
- document micro-frontend cleanup and secure custom event guidance

## Testing
- `pnpm test` *(fails: SyntaxError in scaffold-component.test.js)*
- `node --test tests/events.test.js tests/theme-manager.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcc4b1a6848328813f1ee47b021546