### PR TITLE
feat(figma): add optional sync token

### DIFF
--- a/packages/core/button.js
+++ b/packages/core/button.js
@@ -1,42 +1,6 @@
 import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
-const css = `
-  :host {
-    display: inline-block;
-    container-type: inline-size;
-  }
-
-  button {
-    font: inherit;
-    padding: var(--spacing-sm) var(--spacing-lg);
-    border: none;
-    border-radius: var(--radius-md);
-    background: var(--color-brand);
-    color: var(--color-text);
-    transition: background var(--motion-fast), color var(--motion-fast);
-  }
-  :host([variant="outline"]) button {
-    background: transparent;
-    border: 1px solid var(--color-brand);
-    color: var(--color-brand);
-  }
-  @container (min-width: 480px) {
-    button { padding: var(--spacing-md) var(--spacing-xl); }
-  }
-  button:focus-visible { outline: 2px solid var(--color-text); outline-offset: 2px; }
-  button[disabled] { opacity: 0.6; cursor: not-allowed; }
-  @media (prefers-reduced-motion: reduce) {
-    :host { --motion-fast: 0s; }
-  }
-  @media (prefers-contrast: more) {
-    button {
-      background: var(--color-text);
-      color: var(--color-background);
-    }
-  }
-`;
-
 class CapsButton extends withLocaleDir(HTMLElement) {
   constructor() {
     super();

--- a/plugins/figma-token-sync/README.md
+++ b/plugins/figma-token-sync/README.md
@@ -6,3 +6,7 @@ A Figma plugin for two-way syncing Capsule UI design tokens.
 - **Push** – reads Figma variables and posts an updated token JSON back to the repo, triggering a token rebuild.
 
 Start the local sync server (see [`scripts/figma-sync-server.ts`](../../scripts/figma-sync-server.ts)) and run the plugin inside Figma. The plugin expects the server to be available at `http://localhost:4141`.
+
+## Authentication
+
+Set the `FIGMA_SYNC_TOKEN` environment variable when starting the server to require an access token. Define the same value in `code.js` via the `SYNC_TOKEN` constant and the plugin will include it with each request.

--- a/plugins/figma-token-sync/code.js
+++ b/plugins/figma-token-sync/code.js
@@ -1,11 +1,18 @@
+/* global figma */
 // Capsule Token Sync Figma plugin
 // Pulls design tokens from the local codebase and pushes changes back
 
 const SERVER_URL = 'http://localhost:4141/tokens';
+// Optional token to authenticate with the sync server
+const SYNC_TOKEN = '';
+
+function authHeaders(headers = {}) {
+  return SYNC_TOKEN ? { ...headers, 'X-Figma-Sync-Token': SYNC_TOKEN } : headers;
+}
 
 async function pull() {
   try {
-    const res = await fetch(SERVER_URL);
+    const res = await fetch(SERVER_URL, { headers: authHeaders() });
     if (!res.ok) throw new Error('Failed to fetch tokens');
     const src = await res.json();
     const tokens = flattenTokens(src);
@@ -66,7 +73,7 @@ async function push() {
     }
     await fetch(SERVER_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(tokens, null, 2)
     });
     figma.notify('Tokens pushed to code');

--- a/scripts/figma-sync-server.ts
+++ b/scripts/figma-sync-server.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { promises as fs } from 'fs';
 
 const port = Number(process.env.FIGMA_SYNC_PORT) || 4141;
+const syncToken = process.env.FIGMA_SYNC_TOKEN;
 const root = path.join(__dirname, '..');
 const tokensPath = path.join(root, 'tokens', 'source', 'tokens.json');
 const registryUrl = process.env.THEME_REGISTRY_URL;
@@ -11,6 +12,12 @@ const registryToken = process.env.THEME_REGISTRY_TOKEN;
 const registrySlug = process.env.THEME_REGISTRY_SLUG || 'figma-sync';
 
 const server = http.createServer(async (req, res) => {
+  if (syncToken && req.headers['x-figma-sync-token'] !== syncToken) {
+    res.statusCode = 401;
+    res.end('Unauthorized');
+    return;
+  }
+
   if (req.method === 'GET' && req.url === '/tokens') {
     try {
       const json = await fs.readFile(tokensPath, 'utf8');

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -190,16 +190,7 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       path.join(tempDir, 'packages', 'components', 'index.ts'),
       'utf8'
     );
-    const doc = await readFile(
-      path.join(tempDir, 'docs', 'components', 'example-component.md'),
-      'utf8'
-    );
-    const adr = await readFile(
-      path.join(tempDir, 'docs', 'adr', '001-example-component.md'),
-      'utf8'
-    );
-
-    const arrow = '\u003d>';
+    await readFile(path.join(tempDir, 'docs', 'adr', '001-example-component.md'), 'utf8');
     assert.equal(
       component,
       `export const ExampleComponent = () => {\n  return <div />;\n};\n`
@@ -228,12 +219,12 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       rootIndex,
       `export * from './ExampleComponent/ExampleComponent';\n`
     );
-    const doc = await readFile(
+    const updatedDoc = await readFile(
       path.join(tempDir, 'docs', 'components', 'example-component.md'),
       'utf8'
     );
     assert.equal(
-      doc,
+      updatedDoc,
       `# ExampleComponent\n\nThe ExampleComponent component.\n\n## Usage\n\n\`\`\`tsx\n<ExampleComponent />\n\`\`\`\n`
     );
   } finally {

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -79,6 +79,9 @@ Then run the plugin inside Figma:
 - **Pull** – apply the values from `tokens/source/tokens.json` to Figma variables.
 - **Push** – write updated variables back to `tokens/source/tokens.json` and rebuild the generated artifacts.
 
+Set a `FIGMA_SYNC_TOKEN` environment variable before starting the server and define the same value in the plugin's `SYNC_TOKEN`
+constant to require authentication.
+
 ## Categories & usage
 
 - **Color** – semantic tokens like `background`, `text`, `brand`, `success`, `warning`, and `error`.


### PR DESCRIPTION
## Summary
- secure Figma sync server and plugin with optional token
- document how to enable token authentication
- fix lint issues in button component and scaffold test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4d7d91c832883df0158102c607d