### PR TITLE
docs: add SSR examples for light DOM and CSS Modules

### DIFF
--- a/docs/ssr-seo.md
+++ b/docs/ssr-seo.md
@@ -1,7 +1,11 @@
 # SSR & SEO
 
 Server-side rendering improves perceived performance and lets search engines index
-Capsule components. Render minimal light DOM markup on the server and upgrade it on the
+Capsule components.
+
+### Hydrating custom elements with light‑DOM fallbacks
+
+Render minimal light DOM markup on the server and upgrade it on the
 client once the component JavaScript loads.
 
 ```html
@@ -18,14 +22,47 @@ ce.textContent = btn.textContent;
 btn.replaceWith(ce);
 ```
 
-Framework integrations under `examples/ssr/` show the pattern for React, Vue and Svelte.
-CSS for Web Components can be loaded ahead of time with a customized link element:
+### Server-rendering CSS Modules
+
+Framework adapters ship a CSS Module for each component. When rendering on the
+server, load that stylesheet ahead of time and include it in the HTML so the
+first paint is styled (see `examples/ssr/css-modules`):
+
+```js
+import { readFileSync } from 'node:fs';
+const buttonCss = readFileSync('node_modules/@capsule-ui/core/button.module.css', 'utf8');
+
+res.send(`<!doctype html><head><style>${buttonCss}</style></head>...`);
+```
+
+Alternatively, serve the CSS file and link it in the `<head>`:
+
+```html
+<link rel="stylesheet" href="/button.css" />
+```
+
+### Avoiding flashes of unstyled content
+
+Web Component styles can be pre-registered with a customized link element so
+Shadow‑DOM variants adopt the `CSSStyleSheet` immediately during hydration:
 
 ```html
 <link rel="stylesheet" is="capsule-style" data-module="caps-button" href="/button.css" />
 ```
 
-The `capsule-style` element registers the loaded `CSSStyleSheet` so components can
-adopt it during hydration and avoid a flash of unstyled content. The `light-dom`
-sample illustrates measuring Cumulative Layout Shift during upgrade and records the
-hydration time budget with a Playwright test.
+The `capsule-style` element registers the loaded sheet and prevents a flash of
+unstyled content. The `light-dom` sample illustrates measuring Cumulative Layout
+Shift during upgrade and records the hydration time budget with a Playwright
+test.
+
+### Framework pitfalls
+
+- **Next.js:** CSS Modules imported only on the client cause class name mismatches
+  and FOUC. Import the Capsule stylesheet in the server layer (e.g. `app/layout`)
+  or inline it with `next/head`. Streaming responses should flush style links
+  before any component markup to avoid unstyled flashes.
+- **Nuxt:** Register custom elements in `nuxt.config` under `build.transpile` and
+  include the Capsule CSS file in the `css` array. Omitting either results in the
+  component rendering without styles until hydration completes.
+
+See `examples/ssr/` for complete integrations and Playwright tests.

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -2,13 +2,21 @@
 
 This directory contains reference integrations for server-side rendering with React, Vue and Svelte.
 Each example renders a Capsule button on the server, hydrates it on the client and demonstrates variant
-styling and basic accessibility attributes. CSS for Web Components is loaded using a customized
-`<link rel="stylesheet" is='capsule-style'>` element. The `light-dom` folder shows how to render plain
-HTML on the server and upgrade it to a Web Component on the client.
+styling and basic accessibility attributes. The `light-dom` example shows how to output plain HTML as a
+light‑DOM fallback and upgrade it to a custom element with no layout shift. The `css-modules` example
+renders the class-based flavor and links its stylesheet during SSR to avoid flashes of unstyled content.
+Framework folders illustrate how to preload the component's CSS Module so the markup renders styled on
+first paint.
 
 ## Running an Example
 
-Change into one of the framework folders and install dependencies:
+For the `light-dom` and `css-modules` examples:
+
+```bash
+node server.js
+```
+
+Framework folders (`react`, `vue`, `svelte`) require dependencies:
 
 ```bash
 pnpm install

--- a/examples/ssr/css-modules/README.md
+++ b/examples/ssr/css-modules/README.md
@@ -1,0 +1,18 @@
+# CSS Modules SSR Example
+
+Renders the CSS Modules flavor of Capsule on the server and preloads the stylesheet to avoid flashes of unstyled content.
+
+Server output:
+
+```html
+<button class="button variant-outline">Book now</button>
+```
+
+The stylesheet is linked in the document head so the first paint is styled.
+
+## Running
+
+```bash
+node server.js
+# visit http://localhost:3000
+```

--- a/examples/ssr/css-modules/package.json
+++ b/examples/ssr/css-modules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "css-modules-ssr-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/examples/ssr/css-modules/server.js
+++ b/examples/ssr/css-modules/server.js
@@ -1,0 +1,40 @@
+import http from 'node:http';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const buttonCss = readFileSync(
+  resolve(__dirname, '../../../packages/core/button.module.css'),
+  'utf8'
+);
+
+export function createServer() {
+  return http.createServer((req, res) => {
+    if (req.url === '/button.css') {
+      res.writeHead(200, { 'Content-Type': 'text/css' });
+      res.end(buttonCss);
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>CSS Modules SSR</title>
+<link rel="stylesheet" href="/button.css" />
+</head>
+<body>
+<button class="button variant-outline">Hello from SSR</button>
+</body>
+</html>`);
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const server = createServer();
+  const port = process.env.PORT || 3000;
+  server.listen(port, () => {
+    console.log(`CSS Modules SSR example running at http://localhost:${port}`);
+  });
+}

--- a/examples/ssr/light-dom/README.md
+++ b/examples/ssr/light-dom/README.md
@@ -4,6 +4,22 @@ This example renders a plain `<button>` on the server with precompiled Capsule s
 loaded through a custom `<link rel="stylesheet" is='capsule-style'>` element. On the
 client it upgrades the element to `<caps-button>` without causing layout shift.
 
+Server output:
+
+```html
+<button data-caps-button class="button">Book now</button>
+```
+
+Client hydration:
+
+```js
+import './button.js';
+const fallback = document.querySelector('[data-caps-button]');
+const wc = document.createElement('caps-button');
+wc.textContent = fallback.textContent;
+fallback.replaceWith(wc);
+```
+
 ## Running
 
 ```bash


### PR DESCRIPTION
## Summary
- document hydrating custom elements with light-DOM fallbacks
- provide CSS Modules SSR sample and outline Next.js/Nuxt pitfalls
- add separate CSS Modules example server

## Testing
- `pnpm lint` *(fails: 'figma' is not defined)*
- `npx eslint examples/ssr/css-modules/server.js`
- `node examples/ssr/css-modules/server.js` *(started server then terminated)*
- `node examples/ssr/light-dom/server.js` *(started server then terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc42397d083289f03faeae7fb257c