### PR TITLE
ci: install playwright deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm run lint
       - run: pnpm test
 
@@ -38,4 +39,5 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm run test:a11y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm run lint
       - run: pnpm test
       - uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- install Playwright system dependencies in CI
- do the same in release workflow

## Testing
- `pnpm exec playwright install --with-deps chromium`
- `pnpm run test:a11y`
- `pnpm run lint` *(fails: no-unused-vars and no-undef in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68bda1fece1883288f7ebd41b73d7cf6