### PR TITLE
Fix lint warnings in VSCode extension, Figma plugin, and tests

### DIFF
--- a/packages/capsule-vscode/src/extension.ts
+++ b/packages/capsule-vscode/src/extension.ts
@@ -20,6 +20,7 @@ export function activate(context: ExtensionContext) {
   };
   client = new LanguageClient('capsuleLanguageServer', 'Capsule Language Server', serverOptions, clientOptions);
   client.start();
+  context.subscriptions.push(client);
 }
 
 export function deactivate() {

--- a/plugins/figma-token-sync/code.js
+++ b/plugins/figma-token-sync/code.js
@@ -2,7 +2,6 @@
 // Capsule Token Sync Figma plugin
 // Pulls design tokens from the local codebase and pushes changes back
 
-/* global figma */
 const SERVER_URL = 'http://localhost:4141/tokens';
 // Optional token to authenticate with the sync server
 const SYNC_TOKEN = '';

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -186,11 +186,10 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       path.join(tempDir, 'packages', 'components', 'index.ts'),
       'utf8'
     );
-    const adr = await readFile(
+    await readFile(
       path.join(tempDir, 'docs', 'adr', '001-example-component.md'),
       'utf8'
     );
-    await readFile(path.join(tempDir, 'docs', 'adr', '001-example-component.md'), 'utf8');
 
     assert.equal(
       component,
@@ -217,12 +216,12 @@ test('scaffoldComponent returns true and generates expected files', async () => 
       rootIndex,
       `export * from './ExampleComponent/ExampleComponent';\n`
     );
-    let doc = await readFile(
+    const doc = await readFile(
       path.join(tempDir, 'docs', 'components', 'example-component.md'),
       'utf8'
     );
     assert.equal(
-      updatedDoc,
+      doc,
       `# ExampleComponent\n\nThe ExampleComponent component.\n\n## Usage\n\n\`\`\`tsx\n<ExampleComponent />\n\`\`\`\n`
     );
     assert.equal(


### PR DESCRIPTION
## Summary
- mark VSCode activation context as used by tracking the language client
- remove duplicate global declaration in Figma token sync plugin
- clean up scaffold-component test variables

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: Accessibility check failed – Failed to launch the browser process: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bedfadbd5c8328a5734b4f59e4a970