### PR TITLE
fix runtime style check null stdout

### DIFF
--- a/scripts/check-runtime-styles.mjs
+++ b/scripts/check-runtime-styles.mjs
@@ -15,11 +15,23 @@ const banned = [
 ];
 
 for (const pkg of banned) {
-  const result = spawnSync('rg', ['-l', pkg, '--glob', '!node_modules/**'], { encoding: 'utf8' });
-  if (result.stdout.trim()) {
+  const result = spawnSync('rg', ['-l', pkg, '--glob', '!node_modules/**'], {
+    encoding: 'utf8'
+  });
+
+  // `result.stdout` can be `null` when the spawned process fails. Guard against
+  // this to avoid a `TypeError` when attempting to call `.trim()` on a
+  // `null`/`undefined` value.
+  const output = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+
+  if (output) {
     console.error(
       `Runtime CSS-in-JS package "${pkg}" detected. Set CAPSULE_ALLOW_RUNTIME_STYLES=true to allow.`
     );
     process.exit(1);
+  }
+
+  if (result.error) {
+    throw result.error;
   }
 }


### PR DESCRIPTION
## Summary
- avoid accessing null stdout in runtime style check

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bee4cb0e4883288c02f6a0caa54474