### PR TITLE
fix: clean up modal backdrop event listeners

### DIFF
--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -63,16 +63,19 @@ class CapsModal extends withLocaleDir(HTMLElement) {
         }
       }
     };
+    this._onBackdropClick = () => this.removeAttribute('open');
   }
 
   connectedCallback() {
     super.connectedCallback();
     const backdrop = this.shadowRoot.querySelector('.backdrop');
-    backdrop?.addEventListener('click', () => this.removeAttribute('open'));
+    backdrop?.addEventListener('click', this._onBackdropClick);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    const backdrop = this.shadowRoot.querySelector('.backdrop');
+    backdrop?.removeEventListener('click', this._onBackdropClick);
     document.removeEventListener('keydown', this._onKeyDown);
   }
 


### PR DESCRIPTION
## Summary
- store modal backdrop click handler on the instance for re-use
- remove backdrop click listener during disconnect

## Testing
- `pnpm test` *(fails: Failed to launch the browser process! spawn /root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f825e59c8328b3a425120ab000ba