### PR TITLE
Handle theme loading errors in ThemeManager

### DIFF
--- a/packages/core/theme-manager.js
+++ b/packages/core/theme-manager.js
@@ -60,11 +60,21 @@ export class ThemeManager {
   }
 
   static async load(tenant, url) {
-    if (typeof fetch === 'undefined') return;
-    const res = await fetch(url);
-    const themes = await res.json();
-    for (const [theme, vars] of Object.entries(themes)) {
-      this.registerTheme(tenant, theme, vars);
+    if (typeof fetch === 'undefined') return false;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        console.error(`Failed to load themes from ${url}: ${res.status} ${res.statusText}`);
+        return false;
+      }
+      const themes = await res.json();
+      for (const [theme, vars] of Object.entries(themes)) {
+        this.registerTheme(tenant, theme, vars);
+      }
+      return true;
+    } catch (err) {
+      console.error(`Failed to load themes from ${url}:`, err);
+      return false;
     }
   }
 

--- a/tests/theme-manager.test.js
+++ b/tests/theme-manager.test.js
@@ -34,6 +34,7 @@ test('ThemeManager loads and switches tenant themes at runtime', async () => {
   global.window = dom.window;
   global.document = dom.window.document;
   global.fetch = async () => ({
+    ok: true,
     json: async () => ({
       light: { 'caps-btn-bg': 'white' },
       dark: { 'caps-btn-bg': 'black' },


### PR DESCRIPTION
## Summary
- handle fetch errors when loading themes
- mock fetch response `ok` flag in tests

## Testing
- `pnpm test` *(fails: Failed to launch the browser process! spawn /root/.cache/ms-playwright/chromium-1187/chrome-linux/chrome ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f823671483289cce1aa094d08300