### PR TITLE
Clone select options before sanitizing

### DIFF
--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -80,7 +80,8 @@ class CapsSelect extends HTMLElement {
     select.innerHTML = '';
     for (const node of slot.assignedNodes()) {
       if (node.nodeName === 'OPTION' || node.nodeName === 'OPTGROUP') {
-        select.appendChild(sanitizeNode(node));
+        const clonedNode = node.cloneNode(true);
+        select.appendChild(sanitizeNode(clonedNode));
       }
     }
     if (this.hasAttribute('value')) {

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -2,16 +2,25 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { JSDOM } = require('jsdom');
 
-test('caps-select reflects value and disabled', async () => {
-  const dom = new JSDOM('<!doctype html><html><body></body></html>');
-  global.window = dom.window;
-  global.document = dom.window.document;
-  global.HTMLElement = dom.window.HTMLElement;
-  global.customElements = dom.window.customElements;
-  global.Node = dom.window.Node;
-  global.Element = dom.window.Element;
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLElement = dom.window.HTMLElement;
+global.customElements = dom.window.customElements;
+global.Node = dom.window.Node;
+global.Element = dom.window.Element;
 
-  await import('../packages/core/select.js');
+async function loadCapsSelect() {
+  const module = await import('../packages/core/select.js');
+  const { CapsSelect } = module;
+  if (!customElements.get('caps-select')) {
+    customElements.define('caps-select', CapsSelect);
+  }
+}
+
+test('caps-select reflects value and disabled', async () => {
+  document.body.innerHTML = '';
+  await loadCapsSelect();
 
   const el = document.createElement('caps-select');
   el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
@@ -31,4 +40,35 @@ test('caps-select reflects value and disabled', async () => {
 
   el.disabled = true;
   assert.equal(el.shadowRoot.querySelector('select').disabled, true);
+});
+
+test('caps-select preserves light DOM options when syncing', async () => {
+  document.body.innerHTML = '';
+  await loadCapsSelect();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  el.setAttribute('value', 'b');
+  document.body.appendChild(el);
+
+  const lightOptions = el.querySelectorAll('option');
+  assert.equal(lightOptions.length, 2);
+
+  const internalOptions = el.shadowRoot.querySelectorAll('option');
+  assert.equal(internalOptions.length, 2);
+  assert.notEqual(internalOptions[0], lightOptions[0]);
+
+  const internalSelect = el.shadowRoot.querySelector('select');
+  assert.equal(internalSelect.value, 'b');
+
+  el.innerHTML = '<option value="b">B</option><option value="c">C</option>';
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const updatedLightOptions = el.querySelectorAll('option');
+  assert.equal(updatedLightOptions.length, 2);
+
+  const updatedInternalOptions = el.shadowRoot.querySelectorAll('option');
+  assert.equal(updatedInternalOptions.length, 2);
+  assert.equal(updatedInternalOptions[0].value, 'b');
+  assert.equal(el.shadowRoot.querySelector('select').value, 'b');
 });


### PR DESCRIPTION
## Summary
- clone assigned options and optgroups before sanitizing so the light DOM is preserved
- update select component tests to reuse a shared JSDOM instance and assert cloned options remain visible and value syncing still works

## Testing
- node --test tests/select-component.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d82b8e8c508328be85c0207b5dd6ae