### PR TITLE
Update ThemeManager load return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,10 @@ For multi-tenant apps, `ThemeManager` can load and switch tenant-specific preset
 ```js
 import { ThemeManager } from '@capsule-ui/core';
 
-await ThemeManager.load('tenantA', '/themes/tenant-a.json');
+const loaded = await ThemeManager.load('tenantA', '/themes/tenant-a.json');
+if (!loaded) {
+  console.warn('Falling back to defaults for tenantA');
+}
 ThemeManager.applyTheme('tenantA', 'dark');
 
 // Later, when tearing down a micro-frontend:

--- a/packages/core/theme-manager.d.ts
+++ b/packages/core/theme-manager.d.ts
@@ -1,7 +1,7 @@
 export class ThemeManager {
   static register(tenant: string, variables: Record<string, string | number>): void;
   static registerTheme(tenant: string, theme: string, variables: Record<string, string | number>): void;
-  static load(tenant: string, url: string): Promise<void>;
+  static load(tenant: string, url: string): Promise<boolean>;
   static apply(tenant: string, element?: HTMLElement): void;
   static applyTheme(tenant: string, theme: string, element?: HTMLElement): void;
   static unregister(tenant: string): void;


### PR DESCRIPTION
## Summary
- adjust the ThemeManager type definitions so load returns a boolean success flag
- update the README example to show handling the new boolean result

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82b8ffde08328a977a29678488971