### PR TITLE
Fix modal focus trapping within shadow DOM

### DIFF
--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -50,14 +50,21 @@ class CapsModal extends withLocaleDir(HTMLElement) {
     this._onKeyDown = (e) => {
       if (e.key === 'Escape') this.removeAttribute('open');
       if (e.key === 'Tab') {
-        const focusables = this.shadowRoot.querySelectorAll('.modal a[href], .modal button:not([disabled]), .modal textarea:not([disabled]), .modal input:not([disabled]), .modal select:not([disabled]), .modal [tabindex]:not([tabindex="-1"])');
+        const focusables = Array.from(this.shadowRoot.querySelectorAll('.modal a[href], .modal button:not([disabled]), .modal textarea:not([disabled]), .modal input:not([disabled]), .modal select:not([disabled]), .modal [tabindex]:not([tabindex="-1"])'));
         if (!focusables.length) return;
         const first = focusables[0];
         const last = focusables[focusables.length - 1];
-        if (e.shiftKey && document.activeElement === first) {
+        let activeElement = this.shadowRoot.activeElement;
+        const isShadowActive = focusables.some((el) => el === activeElement || el?.contains?.(activeElement));
+        if (!isShadowActive) {
+          activeElement = document.activeElement;
+        }
+        const isFirstActive = first === activeElement || first?.contains?.(activeElement);
+        const isLastActive = last === activeElement || last?.contains?.(activeElement);
+        if (e.shiftKey && isFirstActive) {
           e.preventDefault();
           last.focus();
-        } else if (!e.shiftKey && document.activeElement === last) {
+        } else if (!e.shiftKey && isLastActive) {
           e.preventDefault();
           first.focus();
         }

--- a/tests/modal-component.test.js
+++ b/tests/modal-component.test.js
@@ -13,7 +13,8 @@ test('caps-modal handles open/close and focus management', async () => {
   global.Event = dom.window.Event;
   global.KeyboardEvent = dom.window.KeyboardEvent;
 
-  await import('../packages/core/modal.js');
+  await import('../packages/core/modal.js?test=open');
+  await customElements.whenDefined('caps-modal');
 
   const trigger = document.getElementById('trigger');
   const el = document.createElement('caps-modal');
@@ -45,6 +46,54 @@ test('caps-modal handles open/close and focus management', async () => {
   assert.equal(document.activeElement, trigger);
 });
 
+test('caps-modal traps focus within the modal when tabbing', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { pretendToBeVisual: true });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.Node = dom.window.Node;
+  global.Element = dom.window.Element;
+  global.Event = dom.window.Event;
+  global.KeyboardEvent = dom.window.KeyboardEvent;
+
+  await import('../packages/core/modal.js?test=trap');
+  await customElements.whenDefined('caps-modal');
+
+  const el = document.createElement('caps-modal');
+  document.body.appendChild(el);
+
+  const modal = el.shadowRoot.querySelector('.modal');
+  const firstWrapper = document.createElement('div');
+  firstWrapper.setAttribute('tabindex', '0');
+  const firstInner = document.createElement('button');
+  firstInner.textContent = 'First inner';
+  firstWrapper.appendChild(firstInner);
+
+  const middleButton = document.createElement('button');
+  middleButton.textContent = 'Middle';
+
+  const lastWrapper = document.createElement('div');
+  lastWrapper.setAttribute('tabindex', '0');
+  const lastInner = document.createElement('button');
+  lastInner.textContent = 'Last inner';
+  lastWrapper.appendChild(lastInner);
+
+  modal.append(firstWrapper, middleButton, lastWrapper);
+
+  el.setAttribute('open', '');
+
+  // shift+tab from first descendant wraps to last focusable
+  firstInner.focus();
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+  assert.equal(el.shadowRoot.activeElement, lastInner);
+
+  // tab from last descendant wraps to first focusable
+  lastInner.focus();
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+  assert.equal(el.shadowRoot.activeElement, firstWrapper);
+});
+
 test('caps-modal supports fullscreen variant', async () => {
   const dom = new JSDOM('<!doctype html><html><body></body></html>');
   global.window = dom.window;
@@ -54,7 +103,8 @@ test('caps-modal supports fullscreen variant', async () => {
   global.Node = dom.window.Node;
   global.Element = dom.window.Element;
 
-  await import('../packages/core/modal.js');
+  await import('../packages/core/modal.js?test=fullscreen');
+  await customElements.whenDefined('caps-modal');
 
   const el = document.createElement('caps-modal');
   el.setAttribute('variant', 'fullscreen');


### PR DESCRIPTION
## Summary
- update the modal keydown handler to detect the focused element inside the shadow root before wrapping focus
- add a regression test that exercises Tab/Shift+Tab focus trapping within the modal content

## Testing
- `node --test tests/modal-component.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d82b8f2b8c832890cdc42d18526ed3