### PR TITLE
Propagate caps-input name attribute to form submissions

### DIFF
--- a/packages/core/input.js
+++ b/packages/core/input.js
@@ -2,6 +2,8 @@ import { withLocaleDir } from './withLocaleDir.js';
 import { instrumentComponent } from './instrument.js';
 
 class CapsInput extends withLocaleDir(HTMLElement) {
+  static formAssociated = true;
+
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
@@ -38,10 +40,39 @@ class CapsInput extends withLocaleDir(HTMLElement) {
       </style>
       <input part="input" />
     `;
+
+    this._internals = null;
+    this._formProxy = null;
+    if (typeof this.attachInternals === 'function') {
+      const internals = this.attachInternals();
+      if (internals && typeof internals.setFormValue === 'function') {
+        this._internals = internals;
+      }
+    }
+
+    if (!this._internals) {
+      this._formProxy = document.createElement('input');
+      this._formProxy.type = 'hidden';
+      this._formProxy.setAttribute('aria-hidden', 'true');
+      this._formProxy.tabIndex = -1;
+      this._formProxy.hidden = true;
+      this._formProxy.style.display = 'none';
+    }
+
+    this._syncFormName(this.getAttribute('name'));
+    this._syncFormValue(this.getAttribute('value'));
+    this._syncFormDisabled(this.hasAttribute('disabled'));
+  }
+
+  connectedCallback() {
+    if (super.connectedCallback) super.connectedCallback();
+    if (this._formProxy && !this.contains(this._formProxy)) {
+      this.append(this._formProxy);
+    }
   }
 
   static get observedAttributes() {
-    return ['value', 'type', 'placeholder', 'disabled', 'aria-label', 'aria-describedby', 'role'];
+    return ['value', 'type', 'placeholder', 'disabled', 'aria-label', 'aria-describedby', 'role', 'name'];
   }
 
   attributeChangedCallback(name, _old, value) {
@@ -55,6 +86,7 @@ class CapsInput extends withLocaleDir(HTMLElement) {
         input.removeAttribute('disabled');
         input.removeAttribute('aria-disabled');
       }
+      this._syncFormDisabled(value !== null);
     } else if (name === 'value') {
       if (value !== null) {
         input.setAttribute('value', value);
@@ -63,9 +95,19 @@ class CapsInput extends withLocaleDir(HTMLElement) {
         input.removeAttribute('value');
         input.value = '';
       }
-    } else if (name.startsWith('aria-') || name === 'role' || name === 'placeholder' || name === 'type') {
+      this._syncFormValue(value);
+    } else if (
+      name.startsWith('aria-') ||
+      name === 'role' ||
+      name === 'placeholder' ||
+      name === 'type' ||
+      name === 'name'
+    ) {
       if (value !== null) input.setAttribute(name, value);
       else input.removeAttribute(name);
+      if (name === 'name') {
+        this._syncFormName(value);
+      }
     }
   }
 
@@ -87,10 +129,59 @@ class CapsInput extends withLocaleDir(HTMLElement) {
   }
 
   set value(v) {
-    if (v) {
-      this.setAttribute('value', v);
+    if (v !== undefined && v !== null) {
+      const stringValue = typeof v === 'string' ? v : String(v);
+      if (stringValue !== '') {
+        this.setAttribute('value', stringValue);
+      } else {
+        this.removeAttribute('value');
+      }
     } else {
       this.removeAttribute('value');
+    }
+  }
+
+  get name() {
+    return this.getAttribute('name') || '';
+  }
+
+  set name(val) {
+    if (val !== undefined && val !== null && val !== '') {
+      this.setAttribute('name', val);
+    } else {
+      this.removeAttribute('name');
+    }
+  }
+
+  _syncFormValue(value) {
+    const nextValue = value ?? '';
+    const stringValue = typeof nextValue === 'string' ? nextValue : String(nextValue);
+    if (this._internals) {
+      this._internals.setFormValue(stringValue);
+    } else if (this._formProxy) {
+      this._formProxy.value = stringValue;
+    }
+  }
+
+  _syncFormName(name) {
+    if (this._formProxy) {
+      if (name) {
+        this._formProxy.setAttribute('name', name);
+      } else {
+        this._formProxy.removeAttribute('name');
+      }
+    }
+  }
+
+  _syncFormDisabled(isDisabled) {
+    if (this._formProxy) {
+      this._formProxy.disabled = Boolean(isDisabled);
+    } else if (this._internals && this._internals.states) {
+      if (isDisabled) {
+        this._internals.states.add('disabled');
+      } else {
+        this._internals.states.delete('disabled');
+      }
     }
   }
 }

--- a/tests/input-component.test.js
+++ b/tests/input-component.test.js
@@ -1,6 +1,15 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 const { JSDOM } = require('jsdom');
+
+let importCounter = 0;
+async function loadInputModule() {
+  const moduleUrl = pathToFileURL(path.resolve(__dirname, '../packages/core/input.js'));
+  moduleUrl.searchParams.set('test', `${importCounter++}`);
+  return import(moduleUrl.href);
+}
 
 test('caps-input reflects value between property and attribute', async () => {
   const dom = new JSDOM('<!doctype html><html><body></body></html>');
@@ -10,7 +19,7 @@ test('caps-input reflects value between property and attribute', async () => {
   global.customElements = dom.window.customElements;
   global.CustomEvent = dom.window.CustomEvent;
 
-  await import('../packages/core/input.js');
+  await loadInputModule();
 
   const el = document.createElement('caps-input');
   document.body.appendChild(el);
@@ -26,4 +35,27 @@ test('caps-input reflects value between property and attribute', async () => {
   el.value = '';
   assert.equal(el.hasAttribute('value'), false);
   assert.equal(el.shadowRoot.querySelector('input').value, '');
+});
+
+test('caps-input forwards name attribute for form submissions', async () => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
+  global.CustomEvent = dom.window.CustomEvent;
+  global.FormData = dom.window.FormData;
+
+  await loadInputModule();
+
+  const form = document.createElement('form');
+  const el = document.createElement('caps-input');
+  el.name = 'email';
+  form.appendChild(el);
+  document.body.appendChild(form);
+
+  el.value = 'user@example.com';
+
+  const data = new FormData(form);
+  assert.equal(data.get('email'), 'user@example.com');
 });


### PR DESCRIPTION
## Summary
- forward the `name` attribute on `<caps-input>` to the internal control and expose `name` accessors
- add form-association support (internals or hidden proxy) so form submissions include caps-input values
- extend the input component tests to cover form submission via `FormData`

## Testing
- node --test tests/input-component.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d82b913b208328901bb50bc4f70ec4