### PR TITLE
Fix package metadata duplication and use TSX for scaffolded components

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
-    "pa11y": "^6.1.1",
-    "jsdom": "^24.0.0",
     "@playwright/test": "^1.48.0",
     "@axe-core/playwright": "^4.10.0",
     "@changesets/changelog-github": "^0.5.1",

--- a/packages/capsule-cli/bin/capsule.js
+++ b/packages/capsule-cli/bin/capsule.js
@@ -222,7 +222,7 @@ export async function scaffoldComponent(rawName, baseDir = 'packages/components'
     const testDir = join(componentDir, '__tests__');
     await mkdir(testDir, { recursive: true });
 
-    const componentFile = join(componentDir, `${name}.ts`);
+    const componentFile = join(componentDir, `${name}.tsx`);
     const styleFile = join(componentDir, 'style.ts');
     const indexFile = join(componentDir, 'index.ts');
     const testFile = join(testDir, `${name}.test.ts`);

--- a/tests/scaffold-component.test.js
+++ b/tests/scaffold-component.test.js
@@ -175,7 +175,7 @@ test('scaffoldComponent returns true and generates expected files', async () => 
     const result = await scaffoldComponent('example-component');
     assert.equal(result, true);
     const baseDir = path.join(tempDir, 'packages', 'components', 'ExampleComponent');
-    const component = await readFile(path.join(baseDir, 'ExampleComponent.ts'), 'utf8');
+    const component = await readFile(path.join(baseDir, 'ExampleComponent.tsx'), 'utf8');
     const style = await readFile(path.join(baseDir, 'style.ts'), 'utf8');
     const index = await readFile(path.join(baseDir, 'index.ts'), 'utf8');
     const testFile = await readFile(


### PR DESCRIPTION
## Summary
- remove duplicate devDependencies from the root package.json
- update the Capsule CLI to generate .tsx files so JSX compiles under TypeScript defaults
- align scaffold-component tests with the new component file extension

## Testing
- node --test tests/scaffold-component.test.js

------
https://chatgpt.com/codex/tasks/task_e_690171a81d788328b38124bfab7421a4