### PR TITLE
ci: standardize deploy workflow on pnpm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install
-      - run: npm run tokens:build
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run tokens:build
       - run: cp examples/index.html dist/index.html
       - run: cp examples/booking-widget.js dist/booking-widget.js
       - run: sed -i 's|./dist/|./|g' dist/index.html


### PR DESCRIPTION
### Motivation
- Standardize the GitHub Pages deploy workflow to use the repository's pnpm toolchain for deterministic installs and consistent CI behavior.

### Description
- Added `pnpm/action-setup@v4` with `version: 10.5.2` prior to Node setup.
- Updated `actions/setup-node@v4` to keep `node-version: 20` and enable `cache: pnpm`.
- Replaced `npm install` with `pnpm install --frozen-lockfile` and `npm run tokens:build` with `pnpm run tokens:build`.
- Left artifact output path (`dist`) and the Pages deploy/upload steps unchanged.

### Testing
- Ran `sed -n '1,240p' .github/workflows/deploy.yml` to inspect the workflow file and it succeeded.
- Ran `nl -ba .github/workflows/deploy.yml | sed -n '1,240p'` to validate line-level changes and it succeeded.
- Ran `git status --short` and the commit operation to verify repository state and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12dbaeb408328af6b3da931f8da49)