### PR TITLE
Refine runtime styles guard to scan real imports only

### DIFF
--- a/scripts/check-runtime-styles.mjs
+++ b/scripts/check-runtime-styles.mjs
@@ -6,6 +6,8 @@ if (allow) {
   process.exit(0);
 }
 
+const includeTests = process.env.CAPSULE_CHECK_RUNTIME_STYLES_INCLUDE_TESTS === 'true';
+
 const banned = [
   'styled-components',
   '@emotion/react',
@@ -14,10 +16,53 @@ const banned = [
   'jss'
 ];
 
+const sourceExtensions = ['js', 'jsx', 'cjs', 'mjs', 'ts', 'tsx'];
+const sourceGlobs = [];
+
+for (const ext of sourceExtensions) {
+  sourceGlobs.push(`packages/**/*.${ext}`);
+  sourceGlobs.push(`scripts/**/*.${ext}`);
+}
+
+sourceGlobs.push('packages/**/*.svelte', 'packages/**/*.vue');
+
+if (includeTests) {
+  for (const ext of sourceExtensions) {
+    sourceGlobs.push(`tests/**/*.${ext}`);
+  }
+}
+
+const ignoreGlobs = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/coverage/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/docs/**',
+  '**/changelog/**',
+  '**/*.min.*'
+];
+
+function buildImportPattern(pkg) {
+  const escaped = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return String.raw`\b(import\s+([^'"();\n]+\s+from\s*)?['"]${escaped}['"]|require\s*\(\s*['"]${escaped}['"]\s*\)|import\s*\(\s*['"]${escaped}['"]\s*\))`;
+}
+
 for (const pkg of banned) {
-  const result = spawnSync('rg', ['-l', pkg, '--glob', '!node_modules/**'], {
-    encoding: 'utf8'
-  });
+  const args = ['-l', buildImportPattern(pkg)];
+
+  for (const glob of sourceGlobs) {
+    args.push('--glob', glob);
+  }
+
+  for (const glob of ignoreGlobs) {
+    args.push('--glob', `!${glob}`);
+  }
+
+  args.push('.');
+
+  const result = spawnSync('rg', args, { encoding: 'utf8' });
 
   // `result.stdout` can be `null` when the spawned process fails. Guard against
   // this to avoid a `TypeError` when attempting to call `.trim()` on a
@@ -29,6 +74,11 @@ for (const pkg of banned) {
       `Runtime CSS-in-JS package "${pkg}" detected. Set CAPSULE_ALLOW_RUNTIME_STYLES=true to allow.`
     );
     process.exit(1);
+  }
+
+  if (typeof result.status === 'number' && result.status > 1) {
+    const stderr = typeof result.stderr === 'string' ? result.stderr.trim() : '';
+    throw new Error(stderr || `rg failed while checking "${pkg}"`);
   }
 
   if (result.error) {

--- a/tests/check-runtime-styles.test.js
+++ b/tests/check-runtime-styles.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFile } = require('node:child_process');
+const { mkdtemp, mkdir, rm, writeFile } = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const script = path.join(root, 'scripts', 'check-runtime-styles.mjs');
+
+function runCheck(cwd, env = {}) {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [script],
+      { cwd, env: { ...process.env, ...env } },
+      (error, stdout, stderr) => {
+        resolve({
+          code: error && typeof error.code === 'number' ? error.code : 0,
+          stdout,
+          stderr
+        });
+      }
+    );
+  });
+}
+
+test('ignores plain text mentions outside explicit imports', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-runtime-styles-'));
+  try {
+    await mkdir(path.join(tmp, 'packages', 'core'), { recursive: true });
+    await writeFile(
+      path.join(tmp, 'packages', 'core', 'README.md'),
+      'Runtime styles note: styled-components may appear in docs.\n',
+      'utf8'
+    );
+    await writeFile(
+      path.join(tmp, 'packages', 'core', 'index.js'),
+      'export const message = "styled-components is just text here";\n',
+      'utf8'
+    );
+
+    const result = await runCheck(tmp);
+    assert.equal(result.code, 0);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test('fails when banned package is imported from source directories', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'capsule-runtime-styles-'));
+  try {
+    await mkdir(path.join(tmp, 'packages', 'core'), { recursive: true });
+    await writeFile(
+      path.join(tmp, 'packages', 'core', 'index.js'),
+      "import styled from 'styled-components';\nexport default styled;\n",
+      'utf8'
+    );
+
+    const result = await runCheck(tmp);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /Runtime CSS-in-JS package "styled-components" detected/);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### Motivation
- The previous runtime-styles check matched package names in arbitrary text and produced false positives from docs and generated files. 
- The goal is to only flag actual import/require/dynamic-import usage in source code while keeping the existing escape hatch behavior.

### Description
- Update `scripts/check-runtime-styles.mjs` to restrict scanning to source paths under `packages/**` and `scripts/**`, and optionally `tests/**` when `CAPSULE_CHECK_RUNTIME_STYLES_INCLUDE_TESTS=true` is set. 
- Replace plain substring matching with an explicit import-pattern regex that matches `import ... from 'pkg'`, side-effect `import('pkg')`, and `require('pkg')`. 
- Add ignore globs to exclude docs, changelogs and common generated output (`node_modules`, `dist`, `build`, `coverage`, `.next`, `.turbo`, `docs`, `changelog`, `*.min.*`). 
- Surface ripgrep execution failures instead of silently passing and keep the existing `CAPSULE_ALLOW_RUNTIME_STYLES=true` early-exit escape hatch. 
- Add `tests/check-runtime-styles.test.js` with fixtures proving plain text mentions no longer fail while real imports still do.

### Testing
- Ran `node --test tests/check-runtime-styles.test.js` and the new tests passed. 
- Executed `node scripts/check-runtime-styles.mjs` in the repo root which returned success with no banned imports present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12dbc7c5c832884c091153c97cbce)