### PR TITLE
Enforce bundle-size checks against distributable artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run tokens:build
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: pnpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run tokens:build
       - run: pnpm run lint
       - run: pnpm test
       - uses: changesets/action@v1

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -1,17 +1,47 @@
 import fs from 'fs';
 import path from 'path';
+import { execFileSync } from 'child_process';
 
-const budgets = [
+/**
+ * Bundle-size checks target distributable artifacts, not source files.
+ *
+ * Prerequisites:
+ * 1) Run `pnpm run tokens:build` so `dist/tokens.js` and `dist/tokens.css` exist.
+ * 2) Keep package manifests aligned with release packaging. Core component checks read
+ *    `npm pack --dry-run --json` metadata and validate `package/<artifact>` entries.
+ */
+
+const tokenBudgets = [
   { file: path.resolve('dist', 'tokens.js'), maxBytes: 5 * 1024 },
-  { file: path.resolve('dist', 'tokens.css'), maxBytes: 5 * 1024 },
-  { file: path.resolve('packages', 'core', 'modal.js'), maxBytes: 6 * 1024 },
-  { file: path.resolve('packages', 'core', 'modal.module.css'), maxBytes: 2 * 1024 },
-  { file: path.resolve('packages', 'core', 'tabs.js'), maxBytes: 6 * 1024 },
-  { file: path.resolve('packages', 'core', 'tabs.module.css'), maxBytes: 2 * 1024 }
+  { file: path.resolve('dist', 'tokens.css'), maxBytes: 5 * 1024 }
 ];
 
+const packedArtifactBudgets = [
+  { packageDir: path.resolve('packages', 'core'), artifactPath: 'modal.js', maxBytes: 6 * 1024 },
+  { packageDir: path.resolve('packages', 'core'), artifactPath: 'modal.module.css', maxBytes: 2 * 1024 },
+  { packageDir: path.resolve('packages', 'core'), artifactPath: 'tabs.js', maxBytes: 6 * 1024 },
+  { packageDir: path.resolve('packages', 'core'), artifactPath: 'tabs.module.css', maxBytes: 2 * 1024 }
+];
+
+function loadPackedFiles(packageDir) {
+  const raw = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: packageDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  const parsed = JSON.parse(raw);
+  const [packInfo] = parsed;
+  if (!packInfo?.files) {
+    throw new Error(`Unable to read packed file metadata for ${packageDir}`);
+  }
+
+  return new Map(packInfo.files.map((file) => [file.path, file.size]));
+}
+
 let withinBudget = true;
-for (const { file, maxBytes } of budgets) {
+
+for (const { file, maxBytes } of tokenBudgets) {
   try {
     const { size } = fs.statSync(file);
     if (size > maxBytes) {
@@ -23,6 +53,39 @@ for (const { file, maxBytes } of budgets) {
   } catch (err) {
     console.error(`Unable to check bundle size at ${file}:`, err.message);
     withinBudget = false;
+  }
+}
+
+const packedFilesByPackage = new Map();
+for (const { packageDir } of packedArtifactBudgets) {
+  if (packedFilesByPackage.has(packageDir)) continue;
+
+  try {
+    packedFilesByPackage.set(packageDir, loadPackedFiles(packageDir));
+  } catch (err) {
+    console.error(`Unable to inspect packed artifacts for ${packageDir}:`, err.message);
+    withinBudget = false;
+  }
+}
+
+for (const { packageDir, artifactPath, maxBytes } of packedArtifactBudgets) {
+  const packedFiles = packedFilesByPackage.get(packageDir);
+  if (!packedFiles) continue;
+
+  const artifactLabel = `${packageDir}#package/${artifactPath}`;
+  const artifactSize = packedFiles.get(artifactPath);
+
+  if (artifactSize === undefined) {
+    console.error(`Unable to find packed artifact ${artifactLabel}`);
+    withinBudget = false;
+    continue;
+  }
+
+  if (artifactSize > maxBytes) {
+    console.error(`Bundle size ${artifactLabel} ${artifactSize} exceeds budget of ${maxBytes} bytes`);
+    withinBudget = false;
+  } else {
+    console.log(`Bundle size ${artifactLabel} ${artifactSize} within budget (${maxBytes} bytes)`);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure bundle-size budgets validate the actual published/distributed artifacts rather than development/source files.
- Keep token-size checks tied to generated outputs from the build stage (tokens in `dist/`).
- Make CI/release workflows build generated artifacts before running tests that include bundle-size checks.

### Description
- Rewrote `scripts/check-bundle-size.mjs` to keep token budgets for `dist/tokens.js` and `dist/tokens.css` and to add packed-artifact budgets driven by `npm pack --dry-run --json` for package artifacts.
- The script now calls `npm pack --dry-run --json` (via `execFileSync`) and inspects the returned `files` entries to validate artifact sizes like `modal.js` and `tabs.js` inside package tarball contents.
- Added top-of-file comments documenting prerequisites, including the requirement to run `pnpm run tokens:build` before the check.
- Updated `.github/workflows/ci.yml` and `.github/workflows/release.yml` to run `pnpm run tokens:build` prior to test steps so bundle-size checks run after build outputs are generated.

### Testing
- Ran `pnpm run tokens:build && pnpm run check:bundle-size` and the bundle-size check completed successfully with all targets reported within budget.
- Verified `npm pack --dry-run --json` is used to enumerate packed files for `packages/core` during the check and that expected artifact paths are discovered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12dc7ea448328ac6627dbaf032952)