### PR TITLE
Harden Docusaurus config and document docs deployment env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ Each forwards attributes and events and keeps the same Style API for
 [framework adapter docs](docs/framework-adapters.md) for usage examples.
 
 
+## Docs deployment environment variables
+
+When building or deploying the Docusaurus site in `website/`, set these environment variables:
+
+- `DOCS_SITE_URL` (**required in production**) – Full docs origin (for example, `https://docs.capsule-ui.dev`).
+- `DOCS_ORGANIZATION_NAME` (**required in production**) – Git host organization/user for edit/deploy metadata.
+- `DOCS_PROJECT_NAME` (**required in production**) – Repository/project name.
+- `DOCS_BASE_URL` (optional, default `/`) – Base path where the docs app is served.
+- `DOCS_GTAG_ID` (optional) – Google Analytics measurement ID. If unset, gtag config is omitted from the build.
+
+`website/docusaurus.config.ts` now throws at startup/build time when `NODE_ENV=production` and required metadata is missing, preventing placeholder deployments.
+
 ## Quick start (vanilla, using the demo widget)
 Drop this into any HTML page:
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,13 +1,49 @@
 import type {Config} from '@docusaurus/types';
 
+const {
+  DOCS_SITE_URL,
+  DOCS_BASE_URL,
+  DOCS_ORGANIZATION_NAME,
+  DOCS_PROJECT_NAME,
+  DOCS_GTAG_ID,
+  NODE_ENV
+} = process.env;
+
+const isProduction = NODE_ENV === 'production';
+
+const requiredProductionEnvVars = {
+  DOCS_SITE_URL,
+  DOCS_ORGANIZATION_NAME,
+  DOCS_PROJECT_NAME
+};
+
+const missingProductionEnvVars = Object.entries(requiredProductionEnvVars)
+  .filter(([, value]) => !value)
+  .map(([name]) => name);
+
+if (isProduction && missingProductionEnvVars.length > 0) {
+  throw new Error(
+    `[docusaurus.config] Missing required production environment variables: ${missingProductionEnvVars.join(', ')}`
+  );
+}
+
+const gtagConfig = DOCS_GTAG_ID
+  ? {
+      gtag: {
+        trackingID: DOCS_GTAG_ID,
+        anonymizeIP: true
+      }
+    }
+  : {};
+
 const config: Config = {
   title: 'Capsule UI',
   tagline: 'Isolated, token-driven components',
-  url: 'https://your-org.github.io',
-  baseUrl: '/capsule-ui/',
+  url: DOCS_SITE_URL ?? 'http://localhost:3000',
+  baseUrl: DOCS_BASE_URL ?? '/',
   favicon: 'img/favicon.ico',
-  organizationName: 'your-org',
-  projectName: 'capsule-ui',
+  organizationName: DOCS_ORGANIZATION_NAME ?? 'capsule-ui',
+  projectName: DOCS_PROJECT_NAME ?? 'capsule-ui',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   presets: [
@@ -25,10 +61,7 @@ const config: Config = {
         theme: {
           customCss: './src/css/custom.css'
         },
-        gtag: {
-          trackingID: 'G-XXXXXXXXXX',
-          anonymizeIP: true
-        }
+        ...gtagConfig
       }
     ]
   ],


### PR DESCRIPTION
### Motivation
- Prevent accidental production deployments with placeholder Docusaurus metadata by making site metadata env-driven and validating it at startup/build time.
- Ensure no placeholder Google Analytics IDs are shipped by only enabling `gtag` when a real ID is provided.
- Make documentation obvious for operators by documenting required/optional docs env vars in the repository README.

### Description
- Replaced hard-coded placeholders in `website/docusaurus.config.ts` with environment-driven values: `DOCS_SITE_URL`, `DOCS_BASE_URL`, `DOCS_ORGANIZATION_NAME`, and `DOCS_PROJECT_NAME`, while keeping safe local defaults for non-production runs.
- Added a production-time assertion that throws an error when `NODE_ENV=production` and any of `DOCS_SITE_URL`, `DOCS_ORGANIZATION_NAME`, or `DOCS_PROJECT_NAME` is missing.
- Gated Google Analytics configuration behind `DOCS_GTAG_ID` so `gtag` is only included when that env var is present.
- Documented the required and optional environment variables in the top-level `README.md` under a new "Docs deployment environment variables" section.

### Testing
- Ran `pnpm --dir website run build` without env vars and observed the new assertion fail as expected, preventing the build from proceeding.
- Ran `DOCS_SITE_URL=https://docs.capsule-ui.dev DOCS_ORGANIZATION_NAME=capsule-ui DOCS_PROJECT_NAME=Capsule-UI pnpm --dir website run build` and confirmed the config validation passed and the build progressed past config parsing.
- The full build with those env vars later failed in this environment due to a downstream Docusaurus runtime error (`require.resolveWeak is not a function`), which is unrelated to the config changes and surfaced after the new validation passed.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12dcd9470832881473a6836902803)