### PR TITLE
Fix caps-select event subscription lifecycle across reconnects

### DIFF
--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -6,10 +6,12 @@ class CapsSelect extends HTMLElement {
 
   #proxy;
   #internals;
+  #selectEl;
+  #isSelectChangeBound = false;
   #proxyValueInputs = new Set();
 
   #onSelectChange = () => {
-    const select = this.shadowRoot.querySelector('select');
+    const select = this.#selectEl;
     if (!select) return;
     this.#reflectValue(select.value);
     this.#syncProxySelection();
@@ -65,10 +67,14 @@ class CapsSelect extends HTMLElement {
     this.#proxy.setAttribute('aria-hidden', 'true');
     this.#proxy.hidden = true;
     this.#proxy.tabIndex = -1;
-    this.shadowRoot.querySelector('select')?.addEventListener('change', this.#onSelectChange);
+    this.#selectEl = this.shadowRoot.querySelector('select');
   }
 
   connectedCallback() {
+    if (this.#selectEl && !this.#isSelectChangeBound) {
+      this.#selectEl.addEventListener('change', this.#onSelectChange);
+      this.#isSelectChangeBound = true;
+    }
     if (this.#proxy && !this.contains(this.#proxy)) {
       this.append(this.#proxy);
     }
@@ -79,7 +85,10 @@ class CapsSelect extends HTMLElement {
   }
 
   disconnectedCallback() {
-    this.shadowRoot.querySelector('select')?.removeEventListener('change', this.#onSelectChange);
+    if (this.#selectEl && this.#isSelectChangeBound) {
+      this.#selectEl.removeEventListener('change', this.#onSelectChange);
+      this.#isSelectChangeBound = false;
+    }
   }
 
   attributeChangedCallback(name, _old, value) {

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -158,3 +158,27 @@ test('caps-select multiple uses ElementInternals FormData when available', async
     }
   }
 });
+
+test('caps-select restores change handling after reconnect', async () => {
+  await setupDom();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  document.body.appendChild(el);
+
+  const receivedChanges = [];
+  el.addEventListener('change', () => {
+    receivedChanges.push(el.value);
+  });
+
+  el.remove();
+  document.body.appendChild(el);
+
+  const internalSelect = el.shadowRoot.querySelector('select');
+  internalSelect.value = 'b';
+  internalSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+  assert.equal(el.getAttribute('value'), 'b');
+  assert.equal(receivedChanges.length, 1);
+  assert.equal(receivedChanges[0], 'b');
+});


### PR DESCRIPTION
### Motivation
- Prevent duplicate or missing `change` listeners on the internal `<select>` when `<caps-select>` is disconnected and reconnected. 
- Stabilize the listener target to avoid repeated `querySelector` lookups and ensure reconnects restore expected behavior. 
- Add a regression test to capture the reconnect case where emitted `change` and reflected `value` must still occur.

### Description
- Store a stable private reference to the internal shadow `<select>` in `CapsSelect` as `#selectEl`. 
- Move `addEventListener('change', this.#onSelectChange)` into `connectedCallback` and protect it with an idempotent guard `#isSelectChangeBound` to avoid duplicate bindings. 
- Keep the `removeEventListener` call in `disconnectedCallback` and reset the guard there to maintain symmetric lifecycle teardown. 
- Add a regression test `caps-select restores change handling after reconnect` in `tests/select-component.test.js` that disconnects and reconnects the element, triggers a value change, and asserts the `value` attribute and `change` event were produced.

### Testing
- Ran `node --test tests/select-component.test.js` which executed the new test and the existing select tests and passed locally (all tests in that file succeeded). 
- Running the full `npm test -- tests/select-component.test.js` in CI failed due to the environment missing the Playwright/Chromium binary required by the repository's `test:a11y` step, not due to the select change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e948d1ac1883288d2a843104c63ff4)