### PR TITLE
Fix caps-select slotchange listener duplication on reconnect

### DIFF
--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -7,6 +7,7 @@ class CapsSelect extends HTMLElement {
   #proxy;
   #internals;
   #proxyValueInputs = new Set();
+  #onSlotChange = () => this.#syncOptions();
 
   #onSelectChange = () => {
     const select = this.shadowRoot.querySelector('select');
@@ -73,12 +74,14 @@ class CapsSelect extends HTMLElement {
       this.append(this.#proxy);
     }
     const slot = this.shadowRoot.querySelector('slot');
-    slot.addEventListener('slotchange', () => this.#syncOptions());
+    slot?.removeEventListener('slotchange', this.#onSlotChange);
+    slot?.addEventListener('slotchange', this.#onSlotChange);
     this.#syncOptions();
     this.#syncInternals();
   }
 
   disconnectedCallback() {
+    this.shadowRoot.querySelector('slot')?.removeEventListener('slotchange', this.#onSlotChange);
     this.shadowRoot.querySelector('select')?.removeEventListener('change', this.#onSelectChange);
   }
 

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -158,3 +158,51 @@ test('caps-select multiple uses ElementInternals FormData when available', async
     }
   }
 });
+
+test('caps-select reconnect does not duplicate slotchange sync handlers', async () => {
+  const window = await setupDom();
+  const proto = window.HTMLElement.prototype;
+  const originalAttachInternals = proto.attachInternals;
+  let setFormValueCalls = 0;
+
+  proto.attachInternals = function attachInternals() {
+    return {
+      setFormValue() {
+        setFormValueCalls += 1;
+      },
+      setValidity() {},
+      states: {
+        add() {},
+        delete() {},
+      },
+    };
+  };
+
+  try {
+    const select = document.createElement('caps-select');
+    select.innerHTML = '<option value="a">A</option>';
+    document.body.appendChild(select);
+
+    const slot = select.shadowRoot.querySelector('slot');
+    assert.ok(slot);
+
+    document.body.removeChild(select);
+    document.body.appendChild(select);
+
+    await Promise.resolve();
+
+    const callsBeforeMutation = setFormValueCalls;
+    select.innerHTML = '<option value="b">B</option>';
+    await Promise.resolve();
+
+    assert.equal(setFormValueCalls - callsBeforeMutation, 1);
+    assert.equal(select.shadowRoot.querySelectorAll('select option').length, 1);
+    assert.equal(select.shadowRoot.querySelector('select').value, 'b');
+  } finally {
+    if (originalAttachInternals) {
+      proto.attachInternals = originalAttachInternals;
+    } else {
+      delete proto.attachInternals;
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent accumulation of duplicate `slotchange` listeners on `caps-select` instances when elements are removed and reattached, which caused `#syncOptions()` side effects to run multiple times per slot mutation.

### Description
- Add a stable private handler field `#onSlotChange = () => this.#syncOptions()` on `CapsSelect` to provide a consistent listener reference.
- In `connectedCallback`, defensively `removeEventListener` then `addEventListener` for the default slot using `#onSlotChange` to avoid duplicate registrations on reconnect.
- In `disconnectedCallback`, remove the `slotchange` listener using the same `#onSlotChange` reference and keep existing `change` listener cleanup.
- Add a regression test `caps-select reconnect does not duplicate slotchange sync handlers` in `tests/select-component.test.js` that disconnects/reconnects a `caps-select`, mutates slotted options, and asserts `#syncOptions()` side effects occur exactly once per mutation (observed via `setFormValue` call count).

### Testing
- Ran `npm test -- tests/select-component.test.js` which initially surfaced a failing assertion and guided a small test adjustment (failure observed before final fix). 
- Ran `node --test tests/select-component.test.js` after the fix, and the test suite for the select tests passed (all assertions in the modified test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e948d300248328ade6a9ad875ebb92)