### PR TITLE
Scope auto-generated tabs panel IDs per component instance

### DIFF
--- a/packages/core/tabs.js
+++ b/packages/core/tabs.js
@@ -3,8 +3,11 @@ import { instrumentComponent } from './instrument.js';
 import { sanitizeNode } from './sanitize.js';
 
 class CapsTabs extends withLocaleDir(HTMLElement) {
+  static instanceCount = 0;
+
   constructor() {
     super();
+    this._instanceId = `inst-${CapsTabs.instanceCount++}`;
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.innerHTML = `
       <style>
@@ -92,7 +95,7 @@ class CapsTabs extends withLocaleDir(HTMLElement) {
         const panel = panels[i];
         if (panel) {
           sanitizeNode(panel);
-          if (!panel.id) panel.id = `caps-panel-${i}`;
+          if (!panel.id) panel.id = `caps-panel-${this._instanceId}-${i}`;
           tab.setAttribute('aria-controls', panel.id);
         }
         const existingClick = handlers.get(tab);

--- a/tests/tabs-selection.test.js
+++ b/tests/tabs-selection.test.js
@@ -98,3 +98,49 @@ test('caps-tabs keeps active tab when slots mutate', async () => {
   assert.equal(t3.getAttribute('aria-selected'), 'false');
   assert.equal(p3.hasAttribute('data-active'), false);
 });
+
+
+test('caps-tabs generates unique panel ids per instance and links tabs correctly', async () => {
+  await setup();
+
+  const tabsA = document.createElement('caps-tabs');
+  const aTab1 = document.createElement('button');
+  aTab1.setAttribute('slot', 'tab');
+  aTab1.textContent = 'A1';
+  const aTab2 = document.createElement('button');
+  aTab2.setAttribute('slot', 'tab');
+  aTab2.textContent = 'A2';
+  const aPanel1 = document.createElement('div');
+  aPanel1.setAttribute('slot', 'panel');
+  aPanel1.textContent = 'Panel A1';
+  const aPanel2 = document.createElement('div');
+  aPanel2.setAttribute('slot', 'panel');
+  aPanel2.textContent = 'Panel A2';
+  tabsA.append(aTab1, aTab2, aPanel1, aPanel2);
+
+  const tabsB = document.createElement('caps-tabs');
+  const bTab1 = document.createElement('button');
+  bTab1.setAttribute('slot', 'tab');
+  bTab1.textContent = 'B1';
+  const bTab2 = document.createElement('button');
+  bTab2.setAttribute('slot', 'tab');
+  bTab2.textContent = 'B2';
+  const bPanel1 = document.createElement('div');
+  bPanel1.setAttribute('slot', 'panel');
+  bPanel1.textContent = 'Panel B1';
+  const bPanel2 = document.createElement('div');
+  bPanel2.setAttribute('slot', 'panel');
+  bPanel2.textContent = 'Panel B2';
+  tabsB.append(bTab1, bTab2, bPanel1, bPanel2);
+
+  document.body.append(tabsA, tabsB);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const generatedPanelIds = [aPanel1.id, aPanel2.id, bPanel1.id, bPanel2.id];
+  assert.equal(new Set(generatedPanelIds).size, generatedPanelIds.length);
+
+  assert.equal(aTab1.getAttribute('aria-controls'), aPanel1.id);
+  assert.equal(aTab2.getAttribute('aria-controls'), aPanel2.id);
+  assert.equal(bTab1.getAttribute('aria-controls'), bPanel1.id);
+  assert.equal(bTab2.getAttribute('aria-controls'), bPanel2.id);
+});


### PR DESCRIPTION
### Motivation
- Prevent collisions when multiple `<caps-tabs>` instances are present by scoping auto-generated `tabpanel` IDs to the component instance. 
- Preserve existing behavior when authors provide their own `panel.id` values. 
- Ensure `aria-controls` on each tab continues to point at the correct panel within the same component instance.

### Description
- Add a per-instance identifier on `CapsTabs` via a static counter and store it as `this._instanceId` in the constructor. 
- Change auto-generated panel IDs from `caps-panel-${i}` to `caps-panel-${this._instanceId}-${i}`, only when `panel.id` is missing. 
- Keep all existing tab behavior and accessibility attributes intact, including `aria-controls` wiring. 
- Add a regression test `caps-tabs generates unique panel ids per instance and links tabs correctly` in `tests/tabs-selection.test.js` that mounts two `<caps-tabs>` instances and verifies ID uniqueness and correct `aria-controls` mapping.

### Testing
- Ran `node --test tests/tabs-selection.test.js` and all tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e948d42aa483288bed727453dec7d6)