### PR TITLE
Validate caps-select `size` attribute before reflecting to DOM

### DIFF
--- a/packages/core/select.js
+++ b/packages/core/select.js
@@ -111,10 +111,22 @@ class CapsSelect extends HTMLElement {
       select.toggleAttribute('required', value !== null);
       this.#proxy?.toggleAttribute('required', value !== null);
     } else if (name === 'size') {
-      if (value !== null) select.setAttribute('size', value);
-      else select.removeAttribute('size');
-      if (value !== null) this.#proxy?.setAttribute('size', value);
-      else this.#proxy?.removeAttribute('size');
+      if (value === null) {
+        select.removeAttribute('size');
+        this.#proxy?.removeAttribute('size');
+      } else {
+        const parsed = Number.parseInt(value, 10);
+        const normalized = Number.isFinite(parsed) && Number.isInteger(parsed) && parsed >= 1
+          ? String(parsed)
+          : null;
+        if (normalized === null) {
+          select.removeAttribute('size');
+          this.#proxy?.removeAttribute('size');
+        } else {
+          select.setAttribute('size', normalized);
+          this.#proxy?.setAttribute('size', normalized);
+        }
+      }
     } else if (name === 'name') {
       if (value !== null) select.setAttribute('name', value);
       else select.removeAttribute('name');

--- a/tests/select-component.test.js
+++ b/tests/select-component.test.js
@@ -205,6 +205,74 @@ test('caps-select reconnect does not duplicate slotchange sync handlers', async 
       delete proto.attachInternals;
     }
   }
+});
+
+test('caps-select size attribute accepts valid numeric value', async () => {
+  await setupDom();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  document.body.appendChild(el);
+
+  el.setAttribute('size', '3');
+
+  const internalSelect = el.shadowRoot.querySelector('select');
+  const proxySelect = el.querySelector('select[slot="proxy"]');
+  assert.equal(internalSelect.getAttribute('size'), '3');
+  assert.equal(proxySelect?.getAttribute('size'), '3');
+});
+
+test('caps-select size attribute rejects non-numeric value', async () => {
+  await setupDom();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  document.body.appendChild(el);
+
+  el.setAttribute('size', 'not-a-number');
+
+  const internalSelect = el.shadowRoot.querySelector('select');
+  const proxySelect = el.querySelector('select[slot="proxy"]');
+  assert.equal(internalSelect.hasAttribute('size'), false);
+  assert.equal(proxySelect?.hasAttribute('size'), false);
+});
+
+test('caps-select size attribute rejects zero and negative values', async () => {
+  await setupDom();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  document.body.appendChild(el);
+
+  el.setAttribute('size', '0');
+  let internalSelect = el.shadowRoot.querySelector('select');
+  let proxySelect = el.querySelector('select[slot="proxy"]');
+  assert.equal(internalSelect.hasAttribute('size'), false);
+  assert.equal(proxySelect?.hasAttribute('size'), false);
+
+  el.setAttribute('size', '-2');
+  internalSelect = el.shadowRoot.querySelector('select');
+  proxySelect = el.querySelector('select[slot="proxy"]');
+  assert.equal(internalSelect.hasAttribute('size'), false);
+  assert.equal(proxySelect?.hasAttribute('size'), false);
+});
+
+test('caps-select size attribute is removed from internal and proxy selects', async () => {
+  await setupDom();
+
+  const el = document.createElement('caps-select');
+  el.innerHTML = '<option value="a">A</option><option value="b">B</option>';
+  document.body.appendChild(el);
+
+  el.setAttribute('size', '4');
+  el.removeAttribute('size');
+
+  const internalSelect = el.shadowRoot.querySelector('select');
+  const proxySelect = el.querySelector('select[slot="proxy"]');
+  assert.equal(internalSelect.hasAttribute('size'), false);
+  assert.equal(proxySelect?.hasAttribute('size'), false);
+});
+
 test('caps-select restores change handling after reconnect', async () => {
   await setupDom();
 


### PR DESCRIPTION
### Motivation
- Ensure the `size` attribute on `caps-select` is normalized and safe before reflecting to internal and proxy `<select>` elements to avoid invalid DOM state.
- Prevent non-numeric, fractional, zero, or negative values from being applied to the rendered selects.

### Description
- Updated `attributeChangedCallback` in `packages/core/select.js` to parse `size` values with `Number.parseInt(value, 10)` and normalize valid integers using `String(parsed)` before reflecting to DOM.
- The branch now accepts only finite integers `>= 1` and removes the `size` attribute from both the internal and proxy selects when the incoming value is `null` or invalid.
- Added tests in `tests/select-component.test.js` that cover a valid numeric size, non-numeric values, zero/negative values, and explicit removal behavior of the `size` attribute.

### Testing
- Ran `node --test tests/select-component.test.js` which executed the test suite including the new `size` tests; all tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f752d922c832884430287303dd39d)