### PR TITLE
Harden ThemeManager.load payload validation

### DIFF
--- a/packages/core/theme-manager.js
+++ b/packages/core/theme-manager.js
@@ -23,6 +23,10 @@ function sanitize(vars) {
   }, {});
 }
 
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function _injectStyle(id, selector, vars) {
   let style = document.getElementById(id);
   if (!style) {
@@ -65,6 +69,16 @@ export class ThemeManager {
         return false;
       }
       const themes = await res.json();
+      if (!isPlainObject(themes)) {
+        console.error(`Invalid themes payload from ${url}: expected an object keyed by theme names.`);
+        return false;
+      }
+      for (const [, vars] of Object.entries(themes)) {
+        if (!isPlainObject(vars)) {
+          console.error(`Invalid themes payload from ${url}: each theme entry must be an object of CSS variables.`);
+          return false;
+        }
+      }
       for (const [theme, vars] of Object.entries(themes)) {
         this.registerTheme(tenant, theme, vars);
       }

--- a/tests/theme-manager.test.js
+++ b/tests/theme-manager.test.js
@@ -43,7 +43,8 @@ test('ThemeManager loads and switches tenant themes at runtime', async () => {
 
   const { ThemeManager } = await import('../packages/core/theme-manager.js');
 
-  await ThemeManager.load('t1', 'themes.json');
+  const loaded = await ThemeManager.load('t1', 'themes.json');
+  assert.equal(loaded, true);
 
   const el = document.createElement('div');
   document.body.append(el);
@@ -59,6 +60,44 @@ test('ThemeManager loads and switches tenant themes at runtime', async () => {
   assert.equal(el.getAttribute('data-theme'), 'dark');
   style = document.getElementById('caps-theme-t1-dark').textContent;
   assert.ok(style.includes('--caps-btn-bg: black'));
+});
+
+test('ThemeManager.load gracefully fails for malformed payload roots', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+
+  const { ThemeManager } = await import('../packages/core/theme-manager.js');
+
+  for (const payload of [null, [], 'bad']) {
+    global.fetch = async () => ({
+      ok: true,
+      json: async () => payload,
+    });
+
+    const loaded = await ThemeManager.load('t1', 'themes.json');
+    assert.equal(loaded, false);
+    assert.equal(document.querySelectorAll('style[id^="caps-theme-t1-"]').length, 0);
+  }
+});
+
+test('ThemeManager.load gracefully fails for malformed theme variable entries', async () => {
+  const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      light: { 'caps-btn-bg': 'white' },
+      dark: null,
+    }),
+  });
+
+  const { ThemeManager } = await import('../packages/core/theme-manager.js');
+  const loaded = await ThemeManager.load('t1', 'themes.json');
+
+  assert.equal(loaded, false);
+  assert.equal(document.querySelectorAll('style[id^="caps-theme-t1-"]').length, 0);
 });
 
 test('ThemeManager sanitizes invalid tenant names', async () => {
@@ -119,4 +158,3 @@ test('ThemeManager can unregister themes and reset attributes', async () => {
   style = document.getElementById('caps-theme-acme-dark');
   assert.equal(style, null);
 });
-


### PR DESCRIPTION
### Motivation
- Ensure `ThemeManager.load` fails gracefully and avoids partial registration when the fetched JSON is not the expected object mapping of theme names to variable objects.
- Prevent runtime errors caused by passing arrays, `null`, primitives, or non-object theme entries into `registerTheme`.

### Description
- Add `isPlainObject` helper and validate the parsed `themes` root after `const themes = await res.json();` to reject non-object roots with a clear `console.error` and return `false`.
- Perform a preflight pass that verifies every theme entry's `vars` is a non-null object before any call to `registerTheme`, logging an error and returning `false` on invalid entries to avoid partial registration.
- Update tests in `tests/theme-manager.test.js` to assert the boolean return from `ThemeManager.load` on success and add cases covering malformed payload roots (`null`, array, string) and an invalid theme entry (`dark: null`), asserting no styles are registered.

### Testing
- Ran `node --test tests/theme-manager.test.js` and all tests passed (7 tests, 0 failures).
- Observed logging of the new error messages for malformed payload cases and verified no `style` elements were created for invalid payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f752effe0832898c44d3d563d10f4)