### PR TITLE
Guard CapsModal keyboard handler when modal is closed

### DIFF
--- a/packages/core/modal.js
+++ b/packages/core/modal.js
@@ -48,6 +48,7 @@ class CapsModal extends withLocaleDir(HTMLElement) {
       <div class="modal" part="modal" role="dialog" aria-modal="true" tabindex="-1"><slot></slot></div>
     `;
     this._onKeyDown = (e) => {
+      if (!this.hasAttribute('open')) return;
       if (e.key === 'Escape') this.removeAttribute('open');
       if (e.key === 'Tab') {
         const modal = this.shadowRoot.querySelector('.modal');

--- a/packages/core/modal.test.js
+++ b/packages/core/modal.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+function withDom(t, html = '<!doctype html><html><body></body></html>') {
+  const dom = new JSDOM(html, { url: 'http://localhost', pretendToBeVisual: true });
+  const { window } = dom;
+  const previousGlobals = new Map();
+  const globals = {
+    window,
+    document: window.document,
+    HTMLElement: window.HTMLElement,
+    customElements: window.customElements,
+    FormData: window.FormData,
+    Event: window.Event,
+    KeyboardEvent: window.KeyboardEvent,
+    ShadowRoot: window.ShadowRoot,
+    Node: window.Node
+  };
+
+  for (const [key, value] of Object.entries(globals)) {
+    previousGlobals.set(key, globalThis[key]);
+    globalThis[key] = value;
+  }
+
+  t.after(() => {
+    dom.window.close();
+    for (const [key, value] of previousGlobals) {
+      if (value === undefined) {
+        delete globalThis[key];
+      } else {
+        globalThis[key] = value;
+      }
+    }
+  });
+
+  return window;
+}
+
+test('caps-modal ignores keyboard handler when closed', async (t) => {
+  const window = withDom(t);
+  await import('./modal.js');
+
+  const modal = window.document.createElement('caps-modal');
+  window.document.body.append(modal);
+
+  let removeCalls = 0;
+  const originalRemoveAttribute = modal.removeAttribute.bind(modal);
+  modal.removeAttribute = (name) => {
+    removeCalls += 1;
+    return originalRemoveAttribute(name);
+  };
+
+  modal._onKeyDown(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+
+  assert.equal(removeCalls, 0);
+  assert.equal(modal.hasAttribute('open'), false);
+});
+
+test('escape keydown on document does not mutate closed modal state', async (t) => {
+  const window = withDom(t);
+  await import('./modal.js');
+
+  const modal = window.document.createElement('caps-modal');
+  window.document.body.append(modal);
+
+  assert.equal(modal.hasAttribute('open'), false);
+
+  let removeCalls = 0;
+  const originalRemoveAttribute = modal.removeAttribute.bind(modal);
+  modal.removeAttribute = (name) => {
+    removeCalls += 1;
+    return originalRemoveAttribute(name);
+  };
+
+  window.document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+  assert.equal(removeCalls, 0);
+  assert.equal(modal.hasAttribute('open'), false);
+});


### PR DESCRIPTION
### Motivation
- Prevent keyboard handling (Escape/Tab) from running when a `caps-modal` host is not open so closed modals do not react to unrelated document key events.
- Preserve the existing behavior where `Escape` closes the modal while it is open by keeping `removeAttribute('open')` for the open state.
- Add focused tests to ensure document-level `Escape` does not mutate the state of a closed modal.

### Description
- Add an early guard in `_onKeyDown` in `packages/core/modal.js` with `if (!this.hasAttribute('open')) return;` so keyboard handling exits immediately when the modal is closed.
- Ensure both the `Escape` close call (`removeAttribute('open')`) and the `Tab` focus-trap logic only run when the host has the `open` attribute, keeping existing behavior when open unchanged.
- Add `packages/core/modal.test.js` which sets up a JSDOM environment and includes tests that verify `_onKeyDown` is ignored when closed and that a document-level `Escape` keydown does not mutate a closed modal.

### Testing
- Ran `node --test packages/core/*.test.js` which executed the new modal tests along with existing tests, and all tests passed.
- The new `modal.test.js` specifically validated that calling `_onKeyDown` with `Escape` while closed does not call `removeAttribute` and that document `Escape` events do not change closed modal state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f752ba5d08328b65d1d79762cbe60)